### PR TITLE
fix #132: don't overwrite k3s custom config

### DIFF
--- a/.github/workflows/test-smol-k8s-lab.yml
+++ b/.github/workflows/test-smol-k8s-lab.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches-ignore:
       - "main"
+    paths-ignore:
+      - ".github/**"
+      - "README.md"
+      - "docs/**"
 jobs:
   smol_k8s_lab_kind:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -74,52 +74,6 @@ smol-k8s-lab
 ```
 
 <details>
-  <summary><h3>Upgrading your config to v1.x</h3></summary>
-
-If you've installed smol-k8s-lab prior to `v1.0.0`, please backup your old configuration, and then remove the `~/.config/smol-k8s-lab/config.yaml` (or `$XDG_CONFIG_HOME/smol-k8s-lab/config.yaml`) file entirely, then run the following:
-
-```yaml
-# this upgrades smol-k8s-lab
-pip3.11 install --upgrade smol-k8s-lab
-
-# this initializes a new configuration
-smol-k8s-lab
-```
-
-### Adding custom Applications
-
-You can create any application you already have an Argo CD application repo for, by following a simple application YAML schema in `~/.config/smol-k8s-lab/config.yaml` like this:
-
-```yaml
-apps:
-  # name of application to create in Argo CD
-  cert_manager:
-    # if set to false, we ignore this app
-    enabled: true
-    argo:
-      # secret keys to pass to Argo CD Application Set Generator
-      secret_keys:
-        # Used for letsencrypt-staging, to generate certs. If set to "" and cert-manager.enabled is true
-        # smol-k8s-lab will prompt for this value and save it back to this file for you.
-        email: ""
-      # git repo to install the Argo CD app from
-      repo: "https://github.com/small-hack/argocd-apps"
-      # path in the argo repo to point to. Trailing slash very important!
-      path: "ingress/cert-manager/"
-      # either the branch or tag to point at in the argo repo above
-      ref: "main"
-      # namespace to install the k8s app in
-      namespace: "ingress"
-      # source repos for cert-manager CD App Project (in addition to cert-manager.argo.repo)
-      project_source_repos:
-        - https://charts.jetstack.io
-```
-
-Note: the above application, cert-manager, is already included as a default application in smol-k8s-lab :)
-
-</details>
-
-<details>
   <summary><h3>Upgrading config from v1.x to v2.x</h3></summary>
 
 If you've installed smol-k8s-lab prior to `v2.0.0`, please backup your old configuration, and then remove the `~/.config/smol-k8s-lab/config.yaml` (or `$XDG_CONFIG_HOME/smol-k8s-lab/config.yaml`) file entirely, then run the following:
@@ -192,6 +146,53 @@ apps:
 ```
 
 </details>
+
+<details>
+  <summary><h3>Upgrading your config to v1.x</h3></summary>
+
+If you've installed smol-k8s-lab prior to `v1.0.0`, please backup your old configuration, and then remove the `~/.config/smol-k8s-lab/config.yaml` (or `$XDG_CONFIG_HOME/smol-k8s-lab/config.yaml`) file entirely, then run the following:
+
+```yaml
+# this upgrades smol-k8s-lab
+pip3.11 install --upgrade smol-k8s-lab
+
+# this initializes a new configuration
+smol-k8s-lab
+```
+
+### Adding custom Applications
+
+You can create any application you already have an Argo CD application repo for, by following a simple application YAML schema in `~/.config/smol-k8s-lab/config.yaml` like this:
+
+```yaml
+apps:
+  # name of application to create in Argo CD
+  cert_manager:
+    # if set to false, we ignore this app
+    enabled: true
+    argo:
+      # secret keys to pass to Argo CD Application Set Generator
+      secret_keys:
+        # Used for letsencrypt-staging, to generate certs. If set to "" and cert-manager.enabled is true
+        # smol-k8s-lab will prompt for this value and save it back to this file for you.
+        email: ""
+      # git repo to install the Argo CD app from
+      repo: "https://github.com/small-hack/argocd-apps"
+      # path in the argo repo to point to. Trailing slash very important!
+      path: "ingress/cert-manager/"
+      # either the branch or tag to point at in the argo repo above
+      ref: "main"
+      # namespace to install the k8s app in
+      namespace: "ingress"
+      # source repos for cert-manager CD App Project (in addition to cert-manager.argo.repo)
+      project_source_repos:
+        - https://charts.jetstack.io
+```
+
+Note: the above application, cert-manager, is already included as a default application in smol-k8s-lab :)
+
+</details>
+
 
 # Under the hood
 Note: this project is not officially affiliated with any of the below tooling or applications.

--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1629 513.5999999999999" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1190 513.5999999999999" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,123 +19,123 @@
         font-weight: 700;
     }
 
-    .terminal-529454265-matrix {
+    .terminal-138740746-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-529454265-title {
+    .terminal-138740746-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-529454265-r1 { fill: #c5c8c6 }
-.terminal-529454265-r2 { fill: #5f87ff }
-.terminal-529454265-r3 { fill: #5f87af;font-style: italic; }
-.terminal-529454265-r4 { fill: #5f87af }
-.terminal-529454265-r5 { fill: #8787ff }
-.terminal-529454265-r6 { fill: #afafff }
-.terminal-529454265-r7 { fill: #87afff }
-.terminal-529454265-r8 { fill: #afafff;font-weight: bold }
-.terminal-529454265-r9 { fill: #868887 }
-.terminal-529454265-r10 { fill: #6179a9 }
-.terminal-529454265-r11 { fill: #6161a9 }
-.terminal-529454265-r12 { fill: #7979a9;font-weight: bold }
-.terminal-529454265-r13 { fill: #4961a9 }
+    .terminal-138740746-r1 { fill: #c5c8c6 }
+.terminal-138740746-r2 { fill: #5f87ff }
+.terminal-138740746-r3 { fill: #5f87af;font-style: italic; }
+.terminal-138740746-r4 { fill: #5f87af }
+.terminal-138740746-r5 { fill: #8787ff }
+.terminal-138740746-r6 { fill: #afafff }
+.terminal-138740746-r7 { fill: #87afff }
+.terminal-138740746-r8 { fill: #afafff;font-weight: bold }
+.terminal-138740746-r9 { fill: #868887 }
+.terminal-138740746-r10 { fill: #6179a9 }
+.terminal-138740746-r11 { fill: #6161a9 }
+.terminal-138740746-r12 { fill: #7979a9;font-weight: bold }
+.terminal-138740746-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-529454265-clip-terminal">
-      <rect x="0" y="0" width="1609.3999999999999" height="462.59999999999997" />
+    <clipPath id="terminal-138740746-clip-terminal">
+      <rect x="0" y="0" width="1170.1999999999998" height="462.59999999999997" />
     </clipPath>
-    <clipPath id="terminal-529454265-line-0">
-    <rect x="0" y="1.5" width="1610.4" height="24.65"/>
+    <clipPath id="terminal-138740746-line-0">
+    <rect x="0" y="1.5" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-1">
-    <rect x="0" y="25.9" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-1">
+    <rect x="0" y="25.9" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-2">
-    <rect x="0" y="50.3" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-2">
+    <rect x="0" y="50.3" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-3">
-    <rect x="0" y="74.7" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-3">
+    <rect x="0" y="74.7" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-4">
-    <rect x="0" y="99.1" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-4">
+    <rect x="0" y="99.1" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-5">
-    <rect x="0" y="123.5" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-5">
+    <rect x="0" y="123.5" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-6">
-    <rect x="0" y="147.9" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-6">
+    <rect x="0" y="147.9" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-7">
-    <rect x="0" y="172.3" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-7">
+    <rect x="0" y="172.3" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-8">
-    <rect x="0" y="196.7" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-8">
+    <rect x="0" y="196.7" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-9">
-    <rect x="0" y="221.1" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-9">
+    <rect x="0" y="221.1" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-10">
-    <rect x="0" y="245.5" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-10">
+    <rect x="0" y="245.5" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-11">
-    <rect x="0" y="269.9" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-11">
+    <rect x="0" y="269.9" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-12">
-    <rect x="0" y="294.3" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-12">
+    <rect x="0" y="294.3" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-13">
-    <rect x="0" y="318.7" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-13">
+    <rect x="0" y="318.7" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-14">
-    <rect x="0" y="343.1" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-14">
+    <rect x="0" y="343.1" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-15">
-    <rect x="0" y="367.5" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-15">
+    <rect x="0" y="367.5" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-16">
-    <rect x="0" y="391.9" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-16">
+    <rect x="0" y="391.9" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-529454265-line-17">
-    <rect x="0" y="416.3" width="1610.4" height="24.65"/>
+<clipPath id="terminal-138740746-line-17">
+    <rect x="0" y="416.3" width="1171.2" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1627" height="511.6" rx="8"/><text class="terminal-529454265-title" fill="#c5c8c6" text-anchor="middle" x="813" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1188" height="511.6" rx="8"/><text class="terminal-138740746-title" fill="#c5c8c6" text-anchor="middle" x="594" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-529454265-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-138740746-clip-terminal)">
     
-    <g class="terminal-529454265-matrix">
-    <text class="terminal-529454265-r1" x="402.6" y="20" textLength="329.4" clip-path="url(#terminal-529454265-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-529454265-r2" x="744.2" y="20" textLength="146.4" clip-path="url(#terminal-529454265-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-529454265-r1" x="1610.4" y="20" textLength="12.2" clip-path="url(#terminal-529454265-line-0)">
-</text><text class="terminal-529454265-r1" x="1610.4" y="44.4" textLength="12.2" clip-path="url(#terminal-529454265-line-1)">
-</text><text class="terminal-529454265-r3" x="402.6" y="68.8" textLength="793" clip-path="url(#terminal-529454265-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-529454265-r1" x="1610.4" y="68.8" textLength="12.2" clip-path="url(#terminal-529454265-line-2)">
-</text><text class="terminal-529454265-r1" x="1610.4" y="93.2" textLength="12.2" clip-path="url(#terminal-529454265-line-3)">
-</text><text class="terminal-529454265-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-529454265-line-4)">Usage:</text><text class="terminal-529454265-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-529454265-line-4)">smol</text><text class="terminal-529454265-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-529454265-line-4)">-k</text><text class="terminal-529454265-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-529454265-line-4)">8s</text><text class="terminal-529454265-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-529454265-line-4)">-l</text><text class="terminal-529454265-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-529454265-line-4)">ab</text><text class="terminal-529454265-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-529454265-line-4)">[OPTIONS]</text><text class="terminal-529454265-r1" x="1610.4" y="117.6" textLength="12.2" clip-path="url(#terminal-529454265-line-4)">
-</text><text class="terminal-529454265-r1" x="1610.4" y="142" textLength="12.2" clip-path="url(#terminal-529454265-line-5)">
-</text><text class="terminal-529454265-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-529454265-line-6)">╭─</text><text class="terminal-529454265-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-529454265-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-529454265-r6" x="219.6" y="166.4" textLength="1366.4" clip-path="url(#terminal-529454265-line-6)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-529454265-r6" x="1586" y="166.4" textLength="24.4" clip-path="url(#terminal-529454265-line-6)">─╮</text><text class="terminal-529454265-r1" x="1610.4" y="166.4" textLength="12.2" clip-path="url(#terminal-529454265-line-6)">
-</text><text class="terminal-529454265-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-529454265-line-7)">│</text><text class="terminal-529454265-r6" x="1598.2" y="190.8" textLength="12.2" clip-path="url(#terminal-529454265-line-7)">│</text><text class="terminal-529454265-r1" x="1610.4" y="190.8" textLength="12.2" clip-path="url(#terminal-529454265-line-7)">
-</text><text class="terminal-529454265-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-529454265-line-8)">│</text><text class="terminal-529454265-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-529454265-line-8)">-c</text><text class="terminal-529454265-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-529454265-line-8)">-</text><text class="terminal-529454265-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-529454265-line-8)">-c</text><text class="terminal-529454265-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-529454265-line-8)">onfig</text><text class="terminal-529454265-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-529454265-line-8)">&#160;CONFIG_FILE</text><text class="terminal-529454265-r1" x="329.4" y="215.2" textLength="646.6" clip-path="url(#terminal-529454265-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;</text><text class="terminal-529454265-r6" x="1598.2" y="215.2" textLength="12.2" clip-path="url(#terminal-529454265-line-8)">│</text><text class="terminal-529454265-r1" x="1610.4" y="215.2" textLength="12.2" clip-path="url(#terminal-529454265-line-8)">
-</text><text class="terminal-529454265-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-529454265-line-9)">│</text><text class="terminal-529454265-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-529454265-line-9)">Defaults&#160;to&#160;</text><text class="terminal-529454265-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-529454265-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-529454265-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-529454265-line-9)">smol</text><text class="terminal-529454265-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-529454265-line-9)">-k</text><text class="terminal-529454265-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-529454265-line-9)">8s</text><text class="terminal-529454265-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-529454265-line-9)">-l</text><text class="terminal-529454265-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-529454265-line-9)">ab</text><text class="terminal-529454265-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-529454265-line-9)">/config.yaml</text><text class="terminal-529454265-r6" x="1598.2" y="239.6" textLength="12.2" clip-path="url(#terminal-529454265-line-9)">│</text><text class="terminal-529454265-r1" x="1610.4" y="239.6" textLength="12.2" clip-path="url(#terminal-529454265-line-9)">
-</text><text class="terminal-529454265-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-529454265-line-10)">│</text><text class="terminal-529454265-r6" x="1598.2" y="264" textLength="12.2" clip-path="url(#terminal-529454265-line-10)">│</text><text class="terminal-529454265-r1" x="1610.4" y="264" textLength="12.2" clip-path="url(#terminal-529454265-line-10)">
-</text><text class="terminal-529454265-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-529454265-line-11)">│</text><text class="terminal-529454265-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-529454265-line-11)">-D</text><text class="terminal-529454265-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-529454265-line-11)">-</text><text class="terminal-529454265-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-529454265-line-11)">-d</text><text class="terminal-529454265-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-529454265-line-11)">elete</text><text class="terminal-529454265-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-529454265-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-529454265-r9" x="329.4" y="288.4" textLength="646.6" clip-path="url(#terminal-529454265-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-529454265-r6" x="1598.2" y="288.4" textLength="12.2" clip-path="url(#terminal-529454265-line-11)">│</text><text class="terminal-529454265-r1" x="1610.4" y="288.4" textLength="12.2" clip-path="url(#terminal-529454265-line-11)">
-</text><text class="terminal-529454265-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-529454265-line-12)">│</text><text class="terminal-529454265-r6" x="1598.2" y="312.8" textLength="12.2" clip-path="url(#terminal-529454265-line-12)">│</text><text class="terminal-529454265-r1" x="1610.4" y="312.8" textLength="12.2" clip-path="url(#terminal-529454265-line-12)">
-</text><text class="terminal-529454265-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-529454265-line-13)">│</text><text class="terminal-529454265-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-529454265-line-13)">-i</text><text class="terminal-529454265-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-529454265-line-13)">-</text><text class="terminal-529454265-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-529454265-line-13)">-i</text><text class="terminal-529454265-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-529454265-line-13)">nteractive</text><text class="terminal-529454265-r1" x="329.4" y="337.2" textLength="414.8" clip-path="url(#terminal-529454265-line-13)">New!&#160;⚙️&#160;Interactively&#160;configures&#160;&#160;</text><text class="terminal-529454265-r2" x="732" y="337.2" textLength="48.8" clip-path="url(#terminal-529454265-line-13)">smol</text><text class="terminal-529454265-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-529454265-line-13)">-k</text><text class="terminal-529454265-r2" x="805.2" y="337.2" textLength="24.4" clip-path="url(#terminal-529454265-line-13)">8s</text><text class="terminal-529454265-r2" x="829.6" y="337.2" textLength="24.4" clip-path="url(#terminal-529454265-line-13)">-l</text><text class="terminal-529454265-r2" x="854" y="337.2" textLength="24.4" clip-path="url(#terminal-529454265-line-13)">ab</text><text class="terminal-529454265-r6" x="1598.2" y="337.2" textLength="12.2" clip-path="url(#terminal-529454265-line-13)">│</text><text class="terminal-529454265-r1" x="1610.4" y="337.2" textLength="12.2" clip-path="url(#terminal-529454265-line-13)">
-</text><text class="terminal-529454265-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-529454265-line-14)">│</text><text class="terminal-529454265-r6" x="1598.2" y="361.6" textLength="12.2" clip-path="url(#terminal-529454265-line-14)">│</text><text class="terminal-529454265-r1" x="1610.4" y="361.6" textLength="12.2" clip-path="url(#terminal-529454265-line-14)">
-</text><text class="terminal-529454265-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-529454265-line-15)">│</text><text class="terminal-529454265-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-529454265-line-15)">-v</text><text class="terminal-529454265-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-529454265-line-15)">-</text><text class="terminal-529454265-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-529454265-line-15)">-v</text><text class="terminal-529454265-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-529454265-line-15)">ersion</text><text class="terminal-529454265-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-529454265-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-529454265-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-529454265-line-15)">smol</text><text class="terminal-529454265-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-529454265-line-15)">-k</text><text class="terminal-529454265-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-529454265-line-15)">8s</text><text class="terminal-529454265-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-529454265-line-15)">-l</text><text class="terminal-529454265-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-529454265-line-15)">ab</text><text class="terminal-529454265-r9" x="732" y="386" textLength="244" clip-path="url(#terminal-529454265-line-15)">&#160;(v2.0.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-529454265-r6" x="1598.2" y="386" textLength="12.2" clip-path="url(#terminal-529454265-line-15)">│</text><text class="terminal-529454265-r1" x="1610.4" y="386" textLength="12.2" clip-path="url(#terminal-529454265-line-15)">
-</text><text class="terminal-529454265-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-529454265-line-16)">│</text><text class="terminal-529454265-r6" x="1598.2" y="410.4" textLength="12.2" clip-path="url(#terminal-529454265-line-16)">│</text><text class="terminal-529454265-r1" x="1610.4" y="410.4" textLength="12.2" clip-path="url(#terminal-529454265-line-16)">
-</text><text class="terminal-529454265-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-529454265-line-17)">│</text><text class="terminal-529454265-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-529454265-line-17)">-h</text><text class="terminal-529454265-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-529454265-line-17)">-</text><text class="terminal-529454265-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-529454265-line-17)">-h</text><text class="terminal-529454265-r5" x="97.6" y="434.8" textLength="36.6" clip-path="url(#terminal-529454265-line-17)">elp</text><text class="terminal-529454265-r1" x="329.4" y="434.8" textLength="646.6" clip-path="url(#terminal-529454265-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-529454265-r6" x="1598.2" y="434.8" textLength="12.2" clip-path="url(#terminal-529454265-line-17)">│</text><text class="terminal-529454265-r1" x="1610.4" y="434.8" textLength="12.2" clip-path="url(#terminal-529454265-line-17)">
-</text><text class="terminal-529454265-r6" x="0" y="459.2" textLength="24.4" clip-path="url(#terminal-529454265-line-18)">╰─</text><text class="terminal-529454265-r6" x="24.4" y="459.2" textLength="1024.8" clip-path="url(#terminal-529454265-line-18)">────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-529454265-r6" x="1049.2" y="459.2" textLength="109.8" clip-path="url(#terminal-529454265-line-18)">&#160;♥&#160;docs:&#160;</text><text class="terminal-529454265-r6" x="1159" y="459.2" textLength="414.8" clip-path="url(#terminal-529454265-line-18)">github.com/small-hack/smol-k8s-lab</text><text class="terminal-529454265-r6" x="1586" y="459.2" textLength="24.4" clip-path="url(#terminal-529454265-line-18)">─╯</text><text class="terminal-529454265-r1" x="1610.4" y="459.2" textLength="12.2" clip-path="url(#terminal-529454265-line-18)">
+    <g class="terminal-138740746-matrix">
+    <text class="terminal-138740746-r1" x="183" y="20" textLength="329.4" clip-path="url(#terminal-138740746-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-138740746-r2" x="524.6" y="20" textLength="146.4" clip-path="url(#terminal-138740746-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-138740746-r1" x="1171.2" y="20" textLength="12.2" clip-path="url(#terminal-138740746-line-0)">
+</text><text class="terminal-138740746-r1" x="1171.2" y="44.4" textLength="12.2" clip-path="url(#terminal-138740746-line-1)">
+</text><text class="terminal-138740746-r3" x="183" y="68.8" textLength="793" clip-path="url(#terminal-138740746-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-138740746-r1" x="1171.2" y="68.8" textLength="12.2" clip-path="url(#terminal-138740746-line-2)">
+</text><text class="terminal-138740746-r1" x="1171.2" y="93.2" textLength="12.2" clip-path="url(#terminal-138740746-line-3)">
+</text><text class="terminal-138740746-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-138740746-line-4)">Usage:</text><text class="terminal-138740746-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-138740746-line-4)">smol</text><text class="terminal-138740746-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-138740746-line-4)">-k</text><text class="terminal-138740746-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-138740746-line-4)">8s</text><text class="terminal-138740746-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-138740746-line-4)">-l</text><text class="terminal-138740746-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-138740746-line-4)">ab</text><text class="terminal-138740746-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-138740746-line-4)">[OPTIONS]</text><text class="terminal-138740746-r1" x="1171.2" y="117.6" textLength="12.2" clip-path="url(#terminal-138740746-line-4)">
+</text><text class="terminal-138740746-r1" x="1171.2" y="142" textLength="12.2" clip-path="url(#terminal-138740746-line-5)">
+</text><text class="terminal-138740746-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-138740746-line-6)">╭─</text><text class="terminal-138740746-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-138740746-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-138740746-r6" x="219.6" y="166.4" textLength="927.2" clip-path="url(#terminal-138740746-line-6)">────────────────────────────────────────────────────────────────────────────</text><text class="terminal-138740746-r6" x="1146.8" y="166.4" textLength="24.4" clip-path="url(#terminal-138740746-line-6)">─╮</text><text class="terminal-138740746-r1" x="1171.2" y="166.4" textLength="12.2" clip-path="url(#terminal-138740746-line-6)">
+</text><text class="terminal-138740746-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-138740746-line-7)">│</text><text class="terminal-138740746-r6" x="1159" y="190.8" textLength="12.2" clip-path="url(#terminal-138740746-line-7)">│</text><text class="terminal-138740746-r1" x="1171.2" y="190.8" textLength="12.2" clip-path="url(#terminal-138740746-line-7)">
+</text><text class="terminal-138740746-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-138740746-line-8)">│</text><text class="terminal-138740746-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-138740746-line-8)">-c</text><text class="terminal-138740746-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-138740746-line-8)">-</text><text class="terminal-138740746-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-138740746-line-8)">-c</text><text class="terminal-138740746-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-138740746-line-8)">onfig</text><text class="terminal-138740746-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-138740746-line-8)">&#160;CONFIG_FILE</text><text class="terminal-138740746-r1" x="329.4" y="215.2" textLength="646.6" clip-path="url(#terminal-138740746-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;</text><text class="terminal-138740746-r6" x="1159" y="215.2" textLength="12.2" clip-path="url(#terminal-138740746-line-8)">│</text><text class="terminal-138740746-r1" x="1171.2" y="215.2" textLength="12.2" clip-path="url(#terminal-138740746-line-8)">
+</text><text class="terminal-138740746-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-138740746-line-9)">│</text><text class="terminal-138740746-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-138740746-line-9)">Defaults&#160;to&#160;</text><text class="terminal-138740746-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-138740746-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-138740746-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-138740746-line-9)">smol</text><text class="terminal-138740746-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-138740746-line-9)">-k</text><text class="terminal-138740746-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-138740746-line-9)">8s</text><text class="terminal-138740746-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-138740746-line-9)">-l</text><text class="terminal-138740746-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-138740746-line-9)">ab</text><text class="terminal-138740746-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-138740746-line-9)">/config.yaml</text><text class="terminal-138740746-r6" x="1159" y="239.6" textLength="12.2" clip-path="url(#terminal-138740746-line-9)">│</text><text class="terminal-138740746-r1" x="1171.2" y="239.6" textLength="12.2" clip-path="url(#terminal-138740746-line-9)">
+</text><text class="terminal-138740746-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-138740746-line-10)">│</text><text class="terminal-138740746-r6" x="1159" y="264" textLength="12.2" clip-path="url(#terminal-138740746-line-10)">│</text><text class="terminal-138740746-r1" x="1171.2" y="264" textLength="12.2" clip-path="url(#terminal-138740746-line-10)">
+</text><text class="terminal-138740746-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-138740746-line-11)">│</text><text class="terminal-138740746-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-138740746-line-11)">-D</text><text class="terminal-138740746-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-138740746-line-11)">-</text><text class="terminal-138740746-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-138740746-line-11)">-d</text><text class="terminal-138740746-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-138740746-line-11)">elete</text><text class="terminal-138740746-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-138740746-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-138740746-r9" x="329.4" y="288.4" textLength="646.6" clip-path="url(#terminal-138740746-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-138740746-r6" x="1159" y="288.4" textLength="12.2" clip-path="url(#terminal-138740746-line-11)">│</text><text class="terminal-138740746-r1" x="1171.2" y="288.4" textLength="12.2" clip-path="url(#terminal-138740746-line-11)">
+</text><text class="terminal-138740746-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-138740746-line-12)">│</text><text class="terminal-138740746-r6" x="1159" y="312.8" textLength="12.2" clip-path="url(#terminal-138740746-line-12)">│</text><text class="terminal-138740746-r1" x="1171.2" y="312.8" textLength="12.2" clip-path="url(#terminal-138740746-line-12)">
+</text><text class="terminal-138740746-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-138740746-line-13)">│</text><text class="terminal-138740746-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-138740746-line-13)">-i</text><text class="terminal-138740746-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-138740746-line-13)">-</text><text class="terminal-138740746-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-138740746-line-13)">-i</text><text class="terminal-138740746-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-138740746-line-13)">nteractive</text><text class="terminal-138740746-r1" x="329.4" y="337.2" textLength="414.8" clip-path="url(#terminal-138740746-line-13)">New!&#160;⚙️&#160;Interactively&#160;configures&#160;&#160;</text><text class="terminal-138740746-r2" x="732" y="337.2" textLength="48.8" clip-path="url(#terminal-138740746-line-13)">smol</text><text class="terminal-138740746-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-138740746-line-13)">-k</text><text class="terminal-138740746-r2" x="805.2" y="337.2" textLength="24.4" clip-path="url(#terminal-138740746-line-13)">8s</text><text class="terminal-138740746-r2" x="829.6" y="337.2" textLength="24.4" clip-path="url(#terminal-138740746-line-13)">-l</text><text class="terminal-138740746-r2" x="854" y="337.2" textLength="24.4" clip-path="url(#terminal-138740746-line-13)">ab</text><text class="terminal-138740746-r6" x="1159" y="337.2" textLength="12.2" clip-path="url(#terminal-138740746-line-13)">│</text><text class="terminal-138740746-r1" x="1171.2" y="337.2" textLength="12.2" clip-path="url(#terminal-138740746-line-13)">
+</text><text class="terminal-138740746-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-138740746-line-14)">│</text><text class="terminal-138740746-r6" x="1159" y="361.6" textLength="12.2" clip-path="url(#terminal-138740746-line-14)">│</text><text class="terminal-138740746-r1" x="1171.2" y="361.6" textLength="12.2" clip-path="url(#terminal-138740746-line-14)">
+</text><text class="terminal-138740746-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-138740746-line-15)">│</text><text class="terminal-138740746-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-138740746-line-15)">-v</text><text class="terminal-138740746-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-138740746-line-15)">-</text><text class="terminal-138740746-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-138740746-line-15)">-v</text><text class="terminal-138740746-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-138740746-line-15)">ersion</text><text class="terminal-138740746-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-138740746-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-138740746-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-138740746-line-15)">smol</text><text class="terminal-138740746-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-138740746-line-15)">-k</text><text class="terminal-138740746-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-138740746-line-15)">8s</text><text class="terminal-138740746-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-138740746-line-15)">-l</text><text class="terminal-138740746-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-138740746-line-15)">ab</text><text class="terminal-138740746-r9" x="732" y="386" textLength="244" clip-path="url(#terminal-138740746-line-15)">&#160;(v2.0.1)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-138740746-r6" x="1159" y="386" textLength="12.2" clip-path="url(#terminal-138740746-line-15)">│</text><text class="terminal-138740746-r1" x="1171.2" y="386" textLength="12.2" clip-path="url(#terminal-138740746-line-15)">
+</text><text class="terminal-138740746-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-138740746-line-16)">│</text><text class="terminal-138740746-r6" x="1159" y="410.4" textLength="12.2" clip-path="url(#terminal-138740746-line-16)">│</text><text class="terminal-138740746-r1" x="1171.2" y="410.4" textLength="12.2" clip-path="url(#terminal-138740746-line-16)">
+</text><text class="terminal-138740746-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-138740746-line-17)">│</text><text class="terminal-138740746-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-138740746-line-17)">-h</text><text class="terminal-138740746-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-138740746-line-17)">-</text><text class="terminal-138740746-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-138740746-line-17)">-h</text><text class="terminal-138740746-r5" x="97.6" y="434.8" textLength="36.6" clip-path="url(#terminal-138740746-line-17)">elp</text><text class="terminal-138740746-r1" x="329.4" y="434.8" textLength="646.6" clip-path="url(#terminal-138740746-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-138740746-r6" x="1159" y="434.8" textLength="12.2" clip-path="url(#terminal-138740746-line-17)">│</text><text class="terminal-138740746-r1" x="1171.2" y="434.8" textLength="12.2" clip-path="url(#terminal-138740746-line-17)">
+</text><text class="terminal-138740746-r6" x="0" y="459.2" textLength="24.4" clip-path="url(#terminal-138740746-line-18)">╰─</text><text class="terminal-138740746-r6" x="24.4" y="459.2" textLength="585.6" clip-path="url(#terminal-138740746-line-18)">────────────────────────────────────────────────</text><text class="terminal-138740746-r6" x="610" y="459.2" textLength="109.8" clip-path="url(#terminal-138740746-line-18)">&#160;♥&#160;docs:&#160;</text><text class="terminal-138740746-r6" x="719.8" y="459.2" textLength="414.8" clip-path="url(#terminal-138740746-line-18)">github.com/small-hack/smol-k8s-lab</text><text class="terminal-138740746-r6" x="1146.8" y="459.2" textLength="24.4" clip-path="url(#terminal-138740746-line-18)">─╯</text><text class="terminal-138740746-r1" x="1171.2" y="459.2" textLength="12.2" clip-path="url(#terminal-138740746-line-18)">
 </text>
     </g>
     </g>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "2.0.0"
+version       = "2.0.1"
 description   = "Bootstrap simple projects on Kubernetes with kind, k3d, and k3s."
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
 version       = "2.0.1"
-description   = "Bootstrap simple projects on Kubernetes with kind, k3d, and k3s."
+description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]
 readme        = "README.md"

--- a/smol_k8s_lab/tui/distro_screen.py
+++ b/smol_k8s_lab/tui/distro_screen.py
@@ -128,9 +128,9 @@ class DistroConfigScreen(Screen):
                     )
         else:
             main_box.mount(
-                    K3ConfigWidget(
+                    K3sConfigWidget(
                         self.current_distro,
-                        DEFAULT_DISTRO_OPTIONS[self.current_distro],
+                        self.cfg.get('k3s', DEFAULT_DISTRO_OPTIONS['k3s']),
                         id=self.current_distro + "-pseudo-screen"
                         )
                     )
@@ -158,7 +158,7 @@ class DistroConfigScreen(Screen):
                         )
             else:
                 self.get_widget_by_id("distro-config-screen").mount(
-                        K3ConfigWidget(
+                        K3sConfigWidget(
                             distro,
                             DEFAULT_DISTRO_OPTIONS[distro],
                             id=distro + "-pseudo-screen"
@@ -253,11 +253,14 @@ class KindConfigWidget(Static):
         # update tabbed content box
         tabbed_content = self.query_one(TabbedContent)
 
-        tabbed_content.border_title = ("Add [i]extra[/] options for "
-                                       "[#C1FF87]kind[/] config files")
+        tabbed_content.border_title = (
+                "Add [i]extra[/] options for [#C1FF87]kind[/] config files"
+                )
 
-        subtitle = ("[b][@click=screen.launch_new_option_modal()]"
-                    "➕ kind option[/][/]")
+        subtitle = (
+                "[b][@click=screen.launch_new_option_modal()] ➕ kind option[/][/]"
+                )
+
         tabbed_content.border_subtitle = subtitle
 
         for tab in self.query("Tab"):
@@ -273,13 +276,13 @@ class KindConfigWidget(Static):
             self.app.action_say(f"Selected tab is {event.tab.id}")
 
 
-class K3ConfigWidget(Static):
+class K3sConfigWidget(Static):
     """ 
     a widget representing the entire kind configuration
     """
     def __init__(self, distro: str, metadata: dict, id: str = "") -> None:
-        self.metadata = metadata
         self.distro = distro
+        self.metadata = metadata
         super().__init__(id=id)
 
     def compose(self) -> ComposeResult:
@@ -289,8 +292,8 @@ class K3ConfigWidget(Static):
         with Grid(classes="k8s-distro-config", id=f"{self.distro}-box"):
 
             # take number of nodes from config and make string
-            nodes = self.metadata.get('nodes', {'control_plane': 1,
-                                                'workers': 0})
+            nodes = self.metadata.get('nodes',
+                                      {'control_plane': 1, 'workers': 0})
             control_nodes = str(nodes.get('control_plane', '1'))
             worker_nodes = str(nodes.get('workers', '0'))
 
@@ -298,5 +301,6 @@ class K3ConfigWidget(Static):
             yield NodeAdjustmentBox(self.distro, control_nodes, worker_nodes)
 
             # take extra k3s args if self.distro is k3s or k3d
-            yield K3sConfig(self.distro, self.metadata['k3s_yaml'],
+            yield K3sConfig(self.distro,
+                            self.metadata['k3s_yaml'],
                             id=f"{self.distro}-widget")

--- a/smol_k8s_lab/tui/distro_widgets/k3s_config.py
+++ b/smol_k8s_lab/tui/distro_widgets/k3s_config.py
@@ -96,11 +96,6 @@ class K3sConfig(Static):
                 if arg:
                     self.generate_row(arg, value)
 
-        # don't remember why we needed this, but testing breaks with these errors if it's on:
-        # RuntimeWarning: Enable tracemalloc to get the object allocation traceback
-        # RuntimeWarning: coroutine 'App.action_focus' was never awaited
-        # self.app.action_focus(self.query_one(".k3s-config-container"))
-
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """
         get pressed button and act on it


### PR DESCRIPTION
- fixes #132 
  - defaults to user passed in k3s config instead of assuming we should use the `DEFAULT_DISTRO_OPTIONS` constant
- cleans up some formatting
- remove dead code
- tests now ignore `docs`, `README.md`, and `.github/**`
- fix readme upgrade ordering
- updated the description of smol-k8s-lab in pyproject.toml to match the brew package