### PR TITLE
add home assistant as a demo app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "2.2.0"
+version       = "2.2.1"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -322,6 +322,27 @@ apps:
           # automatically includes the app's namespace and argocd's namespace
           namespaces: []
 
+  home_assistant:
+    enabled: false
+    description: |
+      ⚠️ [magenta]demo Status[/magenta]
+
+      Home Assistant is a home IOT management solution.
+    argo:
+      secret_keys:
+        hostname: ""
+      repo: https://github.com/small-hack/argocd-apps
+      path: demo/home-assistant/
+      revision: main
+      namespace: home-assistant
+      directory_recursion: false
+      project:
+        source_repos:
+        - http://jessebot.github.io/home-assistant-helm
+        destination:
+          namespaces:
+          - argocd
+
   infisical:
     enabled: false
     description: |


### PR DESCRIPTION
It's been pretty stable for me for a few iterations, so I'm happy to announce adding a basic home assistant Argo CD app natively supported by smol-k8s-lab :tada: 