### PR TITLE
catch existing node taint error, and grab lower case cloudflare token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "3.0.1"
+version       = "3.0.2"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/k8s_apps/ingress/cert_manager.py
+++ b/smol_k8s_lab/k8s_apps/ingress/cert_manager.py
@@ -38,7 +38,7 @@ def create_cluster_issuers(init_values: dict, k8s_obj: K8s = None) -> None:
         # create the cloudflare api token secret
         provider = init_values.get("cluster_issuer_acme_dns01_provider", "")
         if provider == "cloudflare":
-            token_dict = {"token": init_values['CLOUDFLARE_API_TOKEN']}
+            token_dict = {"token": init_values['cloudflare_api_token']}
             k8s_obj.create_secret("cloudflare-api-token",
                                   "cert-manager",
                                   token_dict)

--- a/smol_k8s_lab/k8s_distros/k3s.py
+++ b/smol_k8s_lab/k8s_distros/k3s.py
@@ -105,7 +105,7 @@ def join_k3s_nodes(extra_nodes: dict) -> None:
         # after joining the node make sure the taints are up to date
         if taints:
             for taint in taints:
-                subproc([f"kubectl taint nodes {node} {taint}"])
+                subproc([f"kubectl taint nodes {node} {taint}"], error_ok=True)
 
 
 def uninstall_k3s(cluster_name: str) ->  str:


### PR DESCRIPTION
This fixes an issue where if you have a node that you previously deployed to, it won't error out if it's got a cached taint and we try to apply it again.

Also fixes an issue where we looked for the cloudflare token in uppercase by accident.