### PR TITLE
fix issue where local ip may not be ready yet, so we can't join new nodes yet

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1165 513.5999999999999" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1055 513.5999999999999" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,123 +19,123 @@
         font-weight: 700;
     }
 
-    .terminal-3550214243-matrix {
+    .terminal-1855112250-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3550214243-title {
+    .terminal-1855112250-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3550214243-r1 { fill: #c5c8c6 }
-.terminal-3550214243-r2 { fill: #5f87ff }
-.terminal-3550214243-r3 { fill: #5f87af;font-style: italic; }
-.terminal-3550214243-r4 { fill: #5f87af }
-.terminal-3550214243-r5 { fill: #8787ff }
-.terminal-3550214243-r6 { fill: #afafff }
-.terminal-3550214243-r7 { fill: #87afff }
-.terminal-3550214243-r8 { fill: #afafff;font-weight: bold }
-.terminal-3550214243-r9 { fill: #868887 }
-.terminal-3550214243-r10 { fill: #6179a9 }
-.terminal-3550214243-r11 { fill: #6161a9 }
-.terminal-3550214243-r12 { fill: #7979a9;font-weight: bold }
-.terminal-3550214243-r13 { fill: #4961a9 }
+    .terminal-1855112250-r1 { fill: #c5c8c6 }
+.terminal-1855112250-r2 { fill: #5f87ff }
+.terminal-1855112250-r3 { fill: #5f87af;font-style: italic; }
+.terminal-1855112250-r4 { fill: #5f87af }
+.terminal-1855112250-r5 { fill: #8787ff }
+.terminal-1855112250-r6 { fill: #afafff }
+.terminal-1855112250-r7 { fill: #87afff }
+.terminal-1855112250-r8 { fill: #afafff;font-weight: bold }
+.terminal-1855112250-r9 { fill: #868887 }
+.terminal-1855112250-r10 { fill: #6179a9 }
+.terminal-1855112250-r11 { fill: #6161a9 }
+.terminal-1855112250-r12 { fill: #7979a9;font-weight: bold }
+.terminal-1855112250-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-3550214243-clip-terminal">
-      <rect x="0" y="0" width="1145.8" height="462.59999999999997" />
+    <clipPath id="terminal-1855112250-clip-terminal">
+      <rect x="0" y="0" width="1036.0" height="462.59999999999997" />
     </clipPath>
-    <clipPath id="terminal-3550214243-line-0">
-    <rect x="0" y="1.5" width="1146.8" height="24.65"/>
+    <clipPath id="terminal-1855112250-line-0">
+    <rect x="0" y="1.5" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-1">
-    <rect x="0" y="25.9" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-1">
+    <rect x="0" y="25.9" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-2">
-    <rect x="0" y="50.3" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-2">
+    <rect x="0" y="50.3" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-3">
-    <rect x="0" y="74.7" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-3">
+    <rect x="0" y="74.7" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-4">
-    <rect x="0" y="99.1" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-4">
+    <rect x="0" y="99.1" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-5">
-    <rect x="0" y="123.5" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-5">
+    <rect x="0" y="123.5" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-6">
-    <rect x="0" y="147.9" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-6">
+    <rect x="0" y="147.9" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-7">
-    <rect x="0" y="172.3" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-7">
+    <rect x="0" y="172.3" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-8">
-    <rect x="0" y="196.7" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-8">
+    <rect x="0" y="196.7" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-9">
-    <rect x="0" y="221.1" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-9">
+    <rect x="0" y="221.1" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-10">
-    <rect x="0" y="245.5" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-10">
+    <rect x="0" y="245.5" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-11">
-    <rect x="0" y="269.9" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-11">
+    <rect x="0" y="269.9" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-12">
-    <rect x="0" y="294.3" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-12">
+    <rect x="0" y="294.3" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-13">
-    <rect x="0" y="318.7" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-13">
+    <rect x="0" y="318.7" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-14">
-    <rect x="0" y="343.1" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-14">
+    <rect x="0" y="343.1" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-15">
-    <rect x="0" y="367.5" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-15">
+    <rect x="0" y="367.5" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-16">
-    <rect x="0" y="391.9" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-16">
+    <rect x="0" y="391.9" width="1037" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3550214243-line-17">
-    <rect x="0" y="416.3" width="1146.8" height="24.65"/>
+<clipPath id="terminal-1855112250-line-17">
+    <rect x="0" y="416.3" width="1037" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1163" height="511.6" rx="8"/><text class="terminal-3550214243-title" fill="#c5c8c6" text-anchor="middle" x="581" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1053" height="511.6" rx="8"/><text class="terminal-1855112250-title" fill="#c5c8c6" text-anchor="middle" x="526" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3550214243-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1855112250-clip-terminal)">
     
-    <g class="terminal-3550214243-matrix">
-    <text class="terminal-3550214243-r1" x="170.8" y="20" textLength="329.4" clip-path="url(#terminal-3550214243-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-3550214243-r2" x="512.4" y="20" textLength="146.4" clip-path="url(#terminal-3550214243-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-3550214243-r1" x="1146.8" y="20" textLength="12.2" clip-path="url(#terminal-3550214243-line-0)">
-</text><text class="terminal-3550214243-r1" x="1146.8" y="44.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-1)">
-</text><text class="terminal-3550214243-r3" x="170.8" y="68.8" textLength="793" clip-path="url(#terminal-3550214243-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-3550214243-r1" x="1146.8" y="68.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-2)">
-</text><text class="terminal-3550214243-r1" x="1146.8" y="93.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-3)">
-</text><text class="terminal-3550214243-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-3550214243-line-4)">Usage:</text><text class="terminal-3550214243-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-3550214243-line-4)">smol</text><text class="terminal-3550214243-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-3550214243-line-4)">-k</text><text class="terminal-3550214243-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-3550214243-line-4)">8s</text><text class="terminal-3550214243-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-3550214243-line-4)">-l</text><text class="terminal-3550214243-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-3550214243-line-4)">ab</text><text class="terminal-3550214243-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-3550214243-line-4)">[OPTIONS]</text><text class="terminal-3550214243-r1" x="1146.8" y="117.6" textLength="12.2" clip-path="url(#terminal-3550214243-line-4)">
-</text><text class="terminal-3550214243-r1" x="1146.8" y="142" textLength="12.2" clip-path="url(#terminal-3550214243-line-5)">
-</text><text class="terminal-3550214243-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-3550214243-line-6)">╭─</text><text class="terminal-3550214243-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-3550214243-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-3550214243-r6" x="219.6" y="166.4" textLength="902.8" clip-path="url(#terminal-3550214243-line-6)">──────────────────────────────────────────────────────────────────────────</text><text class="terminal-3550214243-r6" x="1122.4" y="166.4" textLength="24.4" clip-path="url(#terminal-3550214243-line-6)">─╮</text><text class="terminal-3550214243-r1" x="1146.8" y="166.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-6)">
-</text><text class="terminal-3550214243-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-7)">│</text><text class="terminal-3550214243-r6" x="1134.6" y="190.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-7)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-7)">
-</text><text class="terminal-3550214243-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-8)">│</text><text class="terminal-3550214243-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-8)">-c</text><text class="terminal-3550214243-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-8)">-</text><text class="terminal-3550214243-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-8)">-c</text><text class="terminal-3550214243-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-3550214243-line-8)">onfig</text><text class="terminal-3550214243-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-3550214243-line-8)">&#160;CONFIG_FILE</text><text class="terminal-3550214243-r1" x="329.4" y="215.2" textLength="646.6" clip-path="url(#terminal-3550214243-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;</text><text class="terminal-3550214243-r6" x="1134.6" y="215.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-8)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-8)">
-</text><text class="terminal-3550214243-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3550214243-line-9)">│</text><text class="terminal-3550214243-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-3550214243-line-9)">Defaults&#160;to&#160;</text><text class="terminal-3550214243-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-3550214243-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-3550214243-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-3550214243-line-9)">smol</text><text class="terminal-3550214243-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-3550214243-line-9)">-k</text><text class="terminal-3550214243-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-3550214243-line-9)">8s</text><text class="terminal-3550214243-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-3550214243-line-9)">-l</text><text class="terminal-3550214243-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-3550214243-line-9)">ab</text><text class="terminal-3550214243-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-3550214243-line-9)">/config.yaml</text><text class="terminal-3550214243-r6" x="1134.6" y="239.6" textLength="12.2" clip-path="url(#terminal-3550214243-line-9)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3550214243-line-9)">
-</text><text class="terminal-3550214243-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3550214243-line-10)">│</text><text class="terminal-3550214243-r6" x="1134.6" y="264" textLength="12.2" clip-path="url(#terminal-3550214243-line-10)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="264" textLength="12.2" clip-path="url(#terminal-3550214243-line-10)">
-</text><text class="terminal-3550214243-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-11)">│</text><text class="terminal-3550214243-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-3550214243-line-11)">-D</text><text class="terminal-3550214243-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-11)">-</text><text class="terminal-3550214243-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-3550214243-line-11)">-d</text><text class="terminal-3550214243-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-3550214243-line-11)">elete</text><text class="terminal-3550214243-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-3550214243-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-3550214243-r9" x="329.4" y="288.4" textLength="646.6" clip-path="url(#terminal-3550214243-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3550214243-r6" x="1134.6" y="288.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-11)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-11)">
-</text><text class="terminal-3550214243-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-12)">│</text><text class="terminal-3550214243-r6" x="1134.6" y="312.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-12)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-12)">
-</text><text class="terminal-3550214243-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-13)">│</text><text class="terminal-3550214243-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-13)">-i</text><text class="terminal-3550214243-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-13)">-</text><text class="terminal-3550214243-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-13)">-i</text><text class="terminal-3550214243-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-3550214243-line-13)">nteractive</text><text class="terminal-3550214243-r1" x="329.4" y="337.2" textLength="414.8" clip-path="url(#terminal-3550214243-line-13)">New!&#160;⚙️&#160;Interactively&#160;configures&#160;&#160;</text><text class="terminal-3550214243-r2" x="732" y="337.2" textLength="48.8" clip-path="url(#terminal-3550214243-line-13)">smol</text><text class="terminal-3550214243-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-13)">-k</text><text class="terminal-3550214243-r2" x="805.2" y="337.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-13)">8s</text><text class="terminal-3550214243-r2" x="829.6" y="337.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-13)">-l</text><text class="terminal-3550214243-r2" x="854" y="337.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-13)">ab</text><text class="terminal-3550214243-r6" x="1134.6" y="337.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-13)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-13)">
-</text><text class="terminal-3550214243-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-3550214243-line-14)">│</text><text class="terminal-3550214243-r6" x="1134.6" y="361.6" textLength="12.2" clip-path="url(#terminal-3550214243-line-14)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="361.6" textLength="12.2" clip-path="url(#terminal-3550214243-line-14)">
-</text><text class="terminal-3550214243-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-3550214243-line-15)">│</text><text class="terminal-3550214243-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-3550214243-line-15)">-v</text><text class="terminal-3550214243-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-3550214243-line-15)">-</text><text class="terminal-3550214243-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-3550214243-line-15)">-v</text><text class="terminal-3550214243-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-3550214243-line-15)">ersion</text><text class="terminal-3550214243-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-3550214243-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-3550214243-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-3550214243-line-15)">smol</text><text class="terminal-3550214243-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-3550214243-line-15)">-k</text><text class="terminal-3550214243-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-3550214243-line-15)">8s</text><text class="terminal-3550214243-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-3550214243-line-15)">-l</text><text class="terminal-3550214243-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-3550214243-line-15)">ab</text><text class="terminal-3550214243-r9" x="732" y="386" textLength="244" clip-path="url(#terminal-3550214243-line-15)">&#160;(v3.0.2)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3550214243-r6" x="1134.6" y="386" textLength="12.2" clip-path="url(#terminal-3550214243-line-15)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="386" textLength="12.2" clip-path="url(#terminal-3550214243-line-15)">
-</text><text class="terminal-3550214243-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-16)">│</text><text class="terminal-3550214243-r6" x="1134.6" y="410.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-16)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="410.4" textLength="12.2" clip-path="url(#terminal-3550214243-line-16)">
-</text><text class="terminal-3550214243-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-17)">│</text><text class="terminal-3550214243-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-3550214243-line-17)">-h</text><text class="terminal-3550214243-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-17)">-</text><text class="terminal-3550214243-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-3550214243-line-17)">-h</text><text class="terminal-3550214243-r5" x="97.6" y="434.8" textLength="36.6" clip-path="url(#terminal-3550214243-line-17)">elp</text><text class="terminal-3550214243-r1" x="329.4" y="434.8" textLength="646.6" clip-path="url(#terminal-3550214243-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3550214243-r6" x="1134.6" y="434.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-17)">│</text><text class="terminal-3550214243-r1" x="1146.8" y="434.8" textLength="12.2" clip-path="url(#terminal-3550214243-line-17)">
-</text><text class="terminal-3550214243-r6" x="0" y="459.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-18)">╰─</text><text class="terminal-3550214243-r6" x="24.4" y="459.2" textLength="561.2" clip-path="url(#terminal-3550214243-line-18)">──────────────────────────────────────────────</text><text class="terminal-3550214243-r6" x="585.6" y="459.2" textLength="109.8" clip-path="url(#terminal-3550214243-line-18)">&#160;♥&#160;docs:&#160;</text><text class="terminal-3550214243-r6" x="695.4" y="459.2" textLength="414.8" clip-path="url(#terminal-3550214243-line-18)">github.com/small-hack/smol-k8s-lab</text><text class="terminal-3550214243-r6" x="1122.4" y="459.2" textLength="24.4" clip-path="url(#terminal-3550214243-line-18)">─╯</text><text class="terminal-3550214243-r1" x="1146.8" y="459.2" textLength="12.2" clip-path="url(#terminal-3550214243-line-18)">
+    <g class="terminal-1855112250-matrix">
+    <text class="terminal-1855112250-r1" x="122" y="20" textLength="329.4" clip-path="url(#terminal-1855112250-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-1855112250-r2" x="463.6" y="20" textLength="146.4" clip-path="url(#terminal-1855112250-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-1855112250-r1" x="1037" y="20" textLength="12.2" clip-path="url(#terminal-1855112250-line-0)">
+</text><text class="terminal-1855112250-r1" x="1037" y="44.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-1)">
+</text><text class="terminal-1855112250-r3" x="122" y="68.8" textLength="793" clip-path="url(#terminal-1855112250-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-1855112250-r1" x="1037" y="68.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-2)">
+</text><text class="terminal-1855112250-r1" x="1037" y="93.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-3)">
+</text><text class="terminal-1855112250-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-1855112250-line-4)">Usage:</text><text class="terminal-1855112250-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-1855112250-line-4)">smol</text><text class="terminal-1855112250-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-1855112250-line-4)">-k</text><text class="terminal-1855112250-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-1855112250-line-4)">8s</text><text class="terminal-1855112250-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-1855112250-line-4)">-l</text><text class="terminal-1855112250-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-1855112250-line-4)">ab</text><text class="terminal-1855112250-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1855112250-line-4)">[OPTIONS]</text><text class="terminal-1855112250-r1" x="1037" y="117.6" textLength="12.2" clip-path="url(#terminal-1855112250-line-4)">
+</text><text class="terminal-1855112250-r1" x="1037" y="142" textLength="12.2" clip-path="url(#terminal-1855112250-line-5)">
+</text><text class="terminal-1855112250-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1855112250-line-6)">╭─</text><text class="terminal-1855112250-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-1855112250-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-1855112250-r6" x="219.6" y="166.4" textLength="793" clip-path="url(#terminal-1855112250-line-6)">─────────────────────────────────────────────────────────────────</text><text class="terminal-1855112250-r6" x="1012.6" y="166.4" textLength="24.4" clip-path="url(#terminal-1855112250-line-6)">─╮</text><text class="terminal-1855112250-r1" x="1037" y="166.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-6)">
+</text><text class="terminal-1855112250-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-7)">│</text><text class="terminal-1855112250-r6" x="1024.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-7)">│</text><text class="terminal-1855112250-r1" x="1037" y="190.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-7)">
+</text><text class="terminal-1855112250-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-8)">│</text><text class="terminal-1855112250-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-8)">-c</text><text class="terminal-1855112250-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-8)">-</text><text class="terminal-1855112250-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-8)">-c</text><text class="terminal-1855112250-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-1855112250-line-8)">onfig</text><text class="terminal-1855112250-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-1855112250-line-8)">&#160;CONFIG_FILE</text><text class="terminal-1855112250-r1" x="329.4" y="215.2" textLength="646.6" clip-path="url(#terminal-1855112250-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;</text><text class="terminal-1855112250-r6" x="1024.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-8)">│</text><text class="terminal-1855112250-r1" x="1037" y="215.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-8)">
+</text><text class="terminal-1855112250-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1855112250-line-9)">│</text><text class="terminal-1855112250-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-1855112250-line-9)">Defaults&#160;to&#160;</text><text class="terminal-1855112250-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-1855112250-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-1855112250-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-1855112250-line-9)">smol</text><text class="terminal-1855112250-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-1855112250-line-9)">-k</text><text class="terminal-1855112250-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-1855112250-line-9)">8s</text><text class="terminal-1855112250-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-1855112250-line-9)">-l</text><text class="terminal-1855112250-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-1855112250-line-9)">ab</text><text class="terminal-1855112250-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-1855112250-line-9)">/config.yaml</text><text class="terminal-1855112250-r6" x="1024.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1855112250-line-9)">│</text><text class="terminal-1855112250-r1" x="1037" y="239.6" textLength="12.2" clip-path="url(#terminal-1855112250-line-9)">
+</text><text class="terminal-1855112250-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1855112250-line-10)">│</text><text class="terminal-1855112250-r6" x="1024.8" y="264" textLength="12.2" clip-path="url(#terminal-1855112250-line-10)">│</text><text class="terminal-1855112250-r1" x="1037" y="264" textLength="12.2" clip-path="url(#terminal-1855112250-line-10)">
+</text><text class="terminal-1855112250-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-11)">│</text><text class="terminal-1855112250-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-1855112250-line-11)">-D</text><text class="terminal-1855112250-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-11)">-</text><text class="terminal-1855112250-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-1855112250-line-11)">-d</text><text class="terminal-1855112250-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-1855112250-line-11)">elete</text><text class="terminal-1855112250-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-1855112250-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-1855112250-r9" x="329.4" y="288.4" textLength="646.6" clip-path="url(#terminal-1855112250-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1855112250-r6" x="1024.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-11)">│</text><text class="terminal-1855112250-r1" x="1037" y="288.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-11)">
+</text><text class="terminal-1855112250-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-12)">│</text><text class="terminal-1855112250-r6" x="1024.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-12)">│</text><text class="terminal-1855112250-r1" x="1037" y="312.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-12)">
+</text><text class="terminal-1855112250-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-13)">│</text><text class="terminal-1855112250-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-13)">-i</text><text class="terminal-1855112250-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-13)">-</text><text class="terminal-1855112250-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-13)">-i</text><text class="terminal-1855112250-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-1855112250-line-13)">nteractive</text><text class="terminal-1855112250-r1" x="329.4" y="337.2" textLength="414.8" clip-path="url(#terminal-1855112250-line-13)">New!&#160;⚙️&#160;Interactively&#160;configures&#160;&#160;</text><text class="terminal-1855112250-r2" x="732" y="337.2" textLength="48.8" clip-path="url(#terminal-1855112250-line-13)">smol</text><text class="terminal-1855112250-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-13)">-k</text><text class="terminal-1855112250-r2" x="805.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-13)">8s</text><text class="terminal-1855112250-r2" x="829.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-13)">-l</text><text class="terminal-1855112250-r2" x="854" y="337.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-13)">ab</text><text class="terminal-1855112250-r6" x="1024.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-13)">│</text><text class="terminal-1855112250-r1" x="1037" y="337.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-13)">
+</text><text class="terminal-1855112250-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1855112250-line-14)">│</text><text class="terminal-1855112250-r6" x="1024.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1855112250-line-14)">│</text><text class="terminal-1855112250-r1" x="1037" y="361.6" textLength="12.2" clip-path="url(#terminal-1855112250-line-14)">
+</text><text class="terminal-1855112250-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1855112250-line-15)">│</text><text class="terminal-1855112250-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1855112250-line-15)">-v</text><text class="terminal-1855112250-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-1855112250-line-15)">-</text><text class="terminal-1855112250-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-1855112250-line-15)">-v</text><text class="terminal-1855112250-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-1855112250-line-15)">ersion</text><text class="terminal-1855112250-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-1855112250-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-1855112250-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-1855112250-line-15)">smol</text><text class="terminal-1855112250-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-1855112250-line-15)">-k</text><text class="terminal-1855112250-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-1855112250-line-15)">8s</text><text class="terminal-1855112250-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-1855112250-line-15)">-l</text><text class="terminal-1855112250-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-1855112250-line-15)">ab</text><text class="terminal-1855112250-r9" x="732" y="386" textLength="244" clip-path="url(#terminal-1855112250-line-15)">&#160;(v3.0.3)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1855112250-r6" x="1024.8" y="386" textLength="12.2" clip-path="url(#terminal-1855112250-line-15)">│</text><text class="terminal-1855112250-r1" x="1037" y="386" textLength="12.2" clip-path="url(#terminal-1855112250-line-15)">
+</text><text class="terminal-1855112250-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-16)">│</text><text class="terminal-1855112250-r6" x="1024.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-16)">│</text><text class="terminal-1855112250-r1" x="1037" y="410.4" textLength="12.2" clip-path="url(#terminal-1855112250-line-16)">
+</text><text class="terminal-1855112250-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-17)">│</text><text class="terminal-1855112250-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1855112250-line-17)">-h</text><text class="terminal-1855112250-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-17)">-</text><text class="terminal-1855112250-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1855112250-line-17)">-h</text><text class="terminal-1855112250-r5" x="97.6" y="434.8" textLength="36.6" clip-path="url(#terminal-1855112250-line-17)">elp</text><text class="terminal-1855112250-r1" x="329.4" y="434.8" textLength="646.6" clip-path="url(#terminal-1855112250-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1855112250-r6" x="1024.8" y="434.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-17)">│</text><text class="terminal-1855112250-r1" x="1037" y="434.8" textLength="12.2" clip-path="url(#terminal-1855112250-line-17)">
+</text><text class="terminal-1855112250-r6" x="0" y="459.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-18)">╰─</text><text class="terminal-1855112250-r6" x="24.4" y="459.2" textLength="451.4" clip-path="url(#terminal-1855112250-line-18)">─────────────────────────────────────</text><text class="terminal-1855112250-r6" x="475.8" y="459.2" textLength="109.8" clip-path="url(#terminal-1855112250-line-18)">&#160;♥&#160;docs:&#160;</text><text class="terminal-1855112250-r6" x="585.6" y="459.2" textLength="414.8" clip-path="url(#terminal-1855112250-line-18)">github.com/small-hack/smol-k8s-lab</text><text class="terminal-1855112250-r6" x="1012.6" y="459.2" textLength="24.4" clip-path="url(#terminal-1855112250-line-18)">─╯</text><text class="terminal-1855112250-r1" x="1037" y="459.2" textLength="12.2" clip-path="url(#terminal-1855112250-line-18)">
 </text>
     </g>
     </g>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "3.0.2"
+version       = "3.0.3"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]


### PR DESCRIPTION
This patch just loops on getting the local ip address till it's available.

Without this patch, it results in a crash because it tries to cannot strip the whitespace from the end of the ip address because the response from the `kubectl get nodes` is `None`.