### PR TITLE
Add sleeps to node ip search and zitadel api health queries; also improve env var tooltip for sensitive init values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "3.0.3"
+version       = "3.0.4"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/k8s_apps/identity_provider/zitadel_api.py
+++ b/smol_k8s_lab/k8s_apps/identity_provider/zitadel_api.py
@@ -56,6 +56,7 @@ class Zitadel():
         Loops and checks https://{self.api_url}healthz for an HTTP status.
         Returns True when the status code is 200 (success).
         """
+        res = None
         while True:
             log.debug("checking if api is up by querying the healthz endpoint"
                       f" by querying {self.api_url} using verify={self.verify}")
@@ -67,13 +68,16 @@ class Zitadel():
                          "but we'll try again")
                 pass
 
-            if res.status_code == 200:
-                log.info("Zitadel API is up now :)")
-                break
+            if res:
+                if res.status_code == 200:
+                    log.info("Zitadel API is up now :)")
+                    break
+                else:
+                    # sleep just a couple of seconds to avoid being locked out or something
+                    sleep(2)
+                    log.debug("Zitadel API is not yet up :(")
             else:
-                # sleep just a couple of seconds to avoid being locked out or something
                 sleep(2)
-                log.debug("Zitadel API is not yet up :(")
 
         return True
 

--- a/smol_k8s_lab/k8s_distros/k3s.py
+++ b/smol_k8s_lab/k8s_distros/k3s.py
@@ -16,6 +16,7 @@ from os import chmod, remove, path
 import requests
 import stat
 from ruamel.yaml import YAML
+from time import sleep
 
 
 def install_k3s_cluster(cluster_name: str,
@@ -79,6 +80,8 @@ def join_k3s_nodes(extra_nodes: dict) -> None:
 
     # we loop b/c sometimes the server isn't ready yet, so this might return None
     while not k3s_control_plane_ip:
+        # sleep 3 seconds to avoid clogging the logs
+        sleep(3)
         k3s_control_plane_ip = subproc([ip_cmd])
 
     # strips new line character from end of ip address

--- a/smol_k8s_lab/tui/app_widgets/input_widgets.py
+++ b/smol_k8s_lab/tui/app_widgets/input_widgets.py
@@ -110,8 +110,9 @@ class SmolK8sLabCollapsibleInputsWidget(Static):
         tooltip = self.tooltips.get(key, None)
         if not tooltip:
             if self.sensitive:
-                tooltip = (f"To avoid needing to fill {key} in manually, "
-                           "you can export an environment variable.")
+                env_var = "_".join([self.app_name.upper(), key.upper()])
+                tooltip = (f"To avoid needing to fill in this value manually, you"
+                           f" can export ${env_var} as an environment variable.")
             else:
                 if key == "s3_provider":
                     tooltip = "Choose between minio and seaweedfs for a local s3 provider"


### PR DESCRIPTION
- Without the sleeps for the node ip search, when joining a new node and searching for the control plane node's internal IP, it can genearte dozens of log entries clogging up your screen. This waits just 2 seconds between tries to free up some more of your screen.

- Without the sleeps and catching of SSLError for zitadel api health queries, it can sometimes time out before the ssl cert is ready (like if you're using the DNS01 challenge type for the ACME Issuer type), which will cause smol-k8s-lab to just crash in the most depressing way, because then you have to delete the zitadel app of apps, clean up the namespace and try smol-k8s-lab again, which is pain because you have to backup the tls cert if it's letsencrypt-prod or you'll get locked out of ACME's servers for like a month if you're doing a lot of back to back testing D:

- the tooltip improvement was just to avoid the user needing to look up the env var in the docs :)