### PR TITLE
Add sync option to apps in the TUI; fix select bug where distro became 'worker'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "3.1.0"
+version       = "3.2.0"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/bitwarden/bw_cli.py
+++ b/smol_k8s_lab/bitwarden/bw_cli.py
@@ -65,7 +65,8 @@ class BwCLI():
         # make sure there's not a session token in the env vars already
         self.env = {"BW_SESSION": env.get("BW_SESSION", default=None),
                     "PATH": env.get("PATH"),
-                    "HOME": env.get("HOME")}
+                    "HOME": env.get("HOME"),
+                    "NODE_OPTIONS": "--no-deprecation"}
 
         self.password = password
         self.client_id = client_id

--- a/smol_k8s_lab/k8s_tools/argocd_util.py
+++ b/smol_k8s_lab/k8s_tools/argocd_util.py
@@ -15,11 +15,13 @@ def check_if_argocd_app_exists(app: str) -> bool:
         return False
 
 
-def sync_argocd_app(app: str) -> None:
+def sync_argocd_app(app: str):
     """
-    syncs an argocd app
+    syncs an argocd app and returns the result
     """
-    subproc([f"argocd app sync {app}"])
+    subproc([])
+    return subproc(['kubectl config set-context --current --namespace=argocd',
+                    f"argocd app sync {app}"])
 
 
 def install_with_argocd(k8s_obj: K8s, app: str, argo_dict: dict) -> None:

--- a/smol_k8s_lab/k8s_tools/argocd_util.py
+++ b/smol_k8s_lab/k8s_tools/argocd_util.py
@@ -15,13 +15,16 @@ def check_if_argocd_app_exists(app: str) -> bool:
         return False
 
 
-def sync_argocd_app(app: str):
+def sync_argocd_app(app: str, spinner: bool = True):
     """
     syncs an argocd app and returns the result
     """
-    subproc([])
-    return subproc(['kubectl config set-context --current --namespace=argocd',
-                    f"argocd app sync {app}"])
+    if not spinner:
+        subproc(['kubectl config set-context --current --namespace=argocd'],
+                spinner=False, error_ok=True)
+        return subproc([f"argocd app sync {app}"], spinner=False, error_ok=True)
+    else:
+        return subproc([f"argocd app sync {app}"])
 
 
 def install_with_argocd(k8s_obj: K8s, app: str, argo_dict: dict) -> None:

--- a/smol_k8s_lab/tui/apps_screen.py
+++ b/smol_k8s_lab/tui/apps_screen.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3.11
 # smol-k8s-lab libraries
+from smol_k8s_lab.utils.subproc import subproc
 from smol_k8s_lab.k8s_tools.argocd_util import sync_argocd_app
 from smol_k8s_lab.tui.app_widgets.app_inputs_confg import AppInputs
 from smol_k8s_lab.tui.app_widgets.new_app_modal import NewAppModalScreen
@@ -200,18 +201,24 @@ class AppsConfig(Screen):
         """ 
         syncs an existing Argo CD application
         """
-        res = sync_argocd_app(self.previous_app)
+        app = self.previous_app.replace("_","-")
+        res = subproc([f"argocd app sync {app}"], spinner=False, error_ok=True)
+
         if res:
             if isinstance(res, list):
                 response = "\n".join(res)
             else:
                 response = res
+            severity = "warning"
+        else:
+            response = "No response recieved from Argo CD sync..."
+            severity = "information"
 
-            # if result is not valid, notify the user why
-            self.notify(response,
-                        timeout=8,
-                        severity="warning",
-                        title="Argo CD Sync Response\n")
+        # if result is not valid, notify the user why
+        self.notify(response,
+                    timeout=10,
+                    severity=severity,
+                    title="Argo CD Sync Response\n")
 
     @on(SelectionList.SelectionToggled)
     def update_selected_apps(self, event: SelectionList.SelectionToggled) -> None:

--- a/smol_k8s_lab/tui/apps_screen.py
+++ b/smol_k8s_lab/tui/apps_screen.py
@@ -47,10 +47,16 @@ class AppsConfig(Screen):
         # show the footer at bottom of screen or not
         self.show_footer = self.app.cfg['smol_k8s_lab']['tui']['show_footer']
 
-        self.modify_cluster = modify_cluster
-
         # should be the apps section of smol k8s lab config
         self.cfg = config
+
+        # if this is an active cluster or not
+        self.modify_cluster = modify_cluster
+
+        if self.modify_cluster:
+            namespace = self.cfg['argo_cd']['argo']['namespace']
+            subproc(['kubectl config set-context --current --namespace='
+                     f'{namespace}'])
 
         # this is state storage
         self.previous_app = ''
@@ -209,10 +215,10 @@ class AppsConfig(Screen):
                 response = "\n".join(res)
             else:
                 response = res
-            severity = "warning"
+            severity = "information"
         else:
             response = "No response recieved from Argo CD sync..."
-            severity = "information"
+            severity = "warning"
 
         # if result is not valid, notify the user why
         self.notify(response,

--- a/smol_k8s_lab/tui/base.py
+++ b/smol_k8s_lab/tui/base.py
@@ -239,14 +239,15 @@ class BaseApp(App):
         if not new_cluster_button.disabled:
             new_cluster_button.action_press()
 
-    def action_request_apps_cfg(self, app_to_highlight: str = "") -> None:
+    def action_request_apps_cfg(self,
+                                app_to_highlight: str = "", 
+                                modify_cluster: bool = False) -> None:
         """
         launches the argo app config screen
         """
-        if app_to_highlight:
-            self.app.push_screen(AppsConfig(self.cfg['apps'], app_to_highlight))
-        else:
-            self.app.push_screen(AppsConfig(self.cfg['apps'], ""))
+        self.app.push_screen(AppsConfig(self.cfg['apps'],
+                                        app_to_highlight,
+                                        modify_cluster))
 
     def action_request_distro_cfg(self) -> None:
         """

--- a/smol_k8s_lab/tui/base_cluster_modal.py
+++ b/smol_k8s_lab/tui/base_cluster_modal.py
@@ -76,7 +76,8 @@ class ClusterModalScreen(ModalScreen):
             # set the current context to this cluster
             system(f"kubectl config use-context {self.cluster}")
             # call the apps page for this cluster
-            self.app.action_request_apps_cfg()
+            self.app.action_request_apps_cfg(app_to_highlight="",
+                                             modify_cluster=True)
 
         elif event.button.id == "delete-cluster-first-try":
             # don't display the first delete button or the modify button

--- a/smol_k8s_lab/tui/css/apps_config.tcss
+++ b/smol_k8s_lab/tui/css/apps_config.tcss
@@ -24,9 +24,24 @@ $navy: rgb(35,35,54);
     width: 90%;
     height: 92%;
     align: center middle;
+    scrollbar-background: $dark_gray;
+    scrollbar-background-active: $dark_gray;
+    scrollbar-background-hover: $dark_gray;
+    scrollbar-color-active: $sky_blue;
+    scrollbar-color-hover: $light_cornflower;
+    scrollbar-color: $cornflower;
 }
 
 /* --------- LEFT TOP HALF OF SCREEN ------------ */
+
+#selection-list-of-apps {
+    scrollbar-background: $dark_gray;
+    scrollbar-background-active: $dark_gray;
+    scrollbar-background-hover: $dark_gray;
+    scrollbar-color-active: $sky_blue;
+    scrollbar-color-hover: $light_cornflower;
+    scrollbar-color: $cornflower;
+}
 
 /* matches only the left hand side of top half of screen */
 #select-add-apps {
@@ -51,6 +66,12 @@ $navy: rgb(35,35,54);
     grid-rows: 1fr 0.2fr;
     align: center top;
     grid-gutter: 1;
+    scrollbar-background: $dark_gray;
+    scrollbar-background-active: $dark_gray;
+    scrollbar-background-hover: $dark_gray;
+    scrollbar-color-active: $sky_blue;
+    scrollbar-color-hover: $light_cornflower;
+    scrollbar-color: $cornflower;
 }
 
 /* new app and modify globals buttons boxes below the app selection list */

--- a/smol_k8s_lab/tui/css/apps_config.tcss
+++ b/smol_k8s_lab/tui/css/apps_config.tcss
@@ -43,6 +43,10 @@ $navy: rgb(35,35,54);
     scrollbar-color: $cornflower;
 }
 
+#selection-list-of-apps:focus {
+    border: round $light_cornflower
+}
+
 /* matches only the left hand side of top half of screen */
 #select-add-apps {
     border: round $cornflower;
@@ -90,11 +94,14 @@ $navy: rgb(35,35,54);
 /* Matches the "Configure parameters for {app}" input list pane itself */
 #app-inputs-pane {
     border-title-color: $sky_blue;
+    border-subtitle-color: $sky_blue;
     padding-top: 1;
     border: round $cornflower;
     background: $navy 60%;
     margin-right: 1;
     grid-gutter: 1;
+    link-background-hover: $navy;
+    link-color-hover: $orange;
 }
 
 /* each collapsible in the app config panel */

--- a/smol_k8s_lab/tui/distro_screen.py
+++ b/smol_k8s_lab/tui/distro_screen.py
@@ -140,45 +140,46 @@ class DistroConfigScreen(Screen):
         """
         changed currently enabled kubernetes distro in the TUI
         """
-        distro = str(event.value)
+        if event.select.id == "distro-drop-down":
+            distro = str(event.value)
 
-        # disable display on previous distro
-        old_distro_obj = self.get_widget_by_id(f"{self.current_distro}-pseudo-screen")
-        old_distro_obj.display = False
-        self.cfg[self.current_distro]['enabled'] = False
+            # disable display on previous distro
+            old_distro_obj = self.get_widget_by_id(f"{self.current_distro}-pseudo-screen")
+            old_distro_obj.display = False
+            self.cfg[self.current_distro]['enabled'] = False
 
-        # change display to True if the distro is selected
-        try:
-            distro_obj = self.get_widget_by_id(f"{distro}-pseudo-screen")
-            distro_obj.display = True
-        except NoMatches:
-            if distro == 'kind':
-                self.get_widget_by_id("distro-config-screen").mount(
-                        KindConfigWidget(
-                            self.cfg.get('kind', DEFAULT_DISTRO_OPTIONS['kind']),
-                            id="kind-pseudo-screen"
+            # change display to True if the distro is selected
+            try:
+                distro_obj = self.get_widget_by_id(f"{distro}-pseudo-screen")
+                distro_obj.display = True
+            except NoMatches:
+                if distro == 'kind':
+                    self.get_widget_by_id("distro-config-screen").mount(
+                            KindConfigWidget(
+                                self.cfg.get('kind', DEFAULT_DISTRO_OPTIONS['kind']),
+                                id="kind-pseudo-screen"
+                                )
                             )
-                        )
-            else:
-                self.get_widget_by_id("distro-config-screen").mount(
-                        K3sConfigWidget(
-                            distro,
-                            DEFAULT_DISTRO_OPTIONS[distro],
-                            id=distro + "-pseudo-screen"
+                else:
+                    self.get_widget_by_id("distro-config-screen").mount(
+                            K3sConfigWidget(
+                                distro,
+                                DEFAULT_DISTRO_OPTIONS[distro],
+                                id=distro + "-pseudo-screen"
+                                )
                             )
-                        )
 
-        self.cfg[distro]['enabled'] = True
+            self.cfg[distro]['enabled'] = True
 
-        # update the tooltip to be the correct distro's description
-        distro_description = DISTRO_DESC[distro]
-        self.get_widget_by_id("distro-description").update(distro_description)
+            # update the tooltip to be the correct distro's description
+            distro_description = DISTRO_DESC[distro]
+            self.get_widget_by_id("distro-description").update(distro_description)
 
-        self.app.cfg['k8s_distros'][distro]['enabled'] = True
-        self.app.cfg['k8s_distros'][self.current_distro]['enabled'] = False
-        self.app.write_yaml()
+            self.app.cfg['k8s_distros'][distro]['enabled'] = True
+            self.app.cfg['k8s_distros'][self.current_distro]['enabled'] = False
+            self.app.write_yaml()
 
-        self.current_distro = distro
+            self.current_distro = distro
 
     def action_launch_new_option_modal(self) -> None:
         """

--- a/smol_k8s_lab/tui/distro_widgets/add_nodes.py
+++ b/smol_k8s_lab/tui/distro_widgets/add_nodes.py
@@ -13,7 +13,7 @@ from textual.widgets import Label, DataTable, Button
 placeholder = """
 [grey53]
                _____
-              /     \\
+              /     |
               vvvvvvv  /|__/|
                  I   /O,O   |
                  I /_____   |      /|/|
@@ -23,6 +23,7 @@ placeholder = """
 
                 "Totoros" (from "My Neighbor Totoro")
                     --- Duke Lee
+[/grey53]
 """
 
 class AddNodesBox(Widget):


### PR DESCRIPTION
This also fixes the node deprecation error from the bw cli.

Quick run through of new feature:

https://github.com/small-hack/smol-k8s-lab/assets/2389292/deefc6ff-116c-41a8-a4d4-75ae6575a749

There are no captions above, but as a quick transcript, I note that after you have an existing cluster, if you click it, then select the modify button, you will go to the apps screen. From the apps screen, if an app is enabled, in the app input panel on the right, in the bottom right corner of the border, there will now be a "🔁 sync" button. If you click that button, it will sync your Argo CD app if it already exists, and then it will output the result into a notification that can be clicked to make it go away. I also note in the video that in the future, I'd like apps that haven't been installed to have an install button, so you can install new apps directly via the tui instead having to click through to the cli run. Thanks!
