### PR TITLE
Allow project names; clean up docs; reduce logging unless debug is enabled

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1434 513.5999999999999" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1409 513.5999999999999" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,123 +19,123 @@
         font-weight: 700;
     }
 
-    .terminal-1365407539-matrix {
+    .terminal-3789971527-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1365407539-title {
+    .terminal-3789971527-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1365407539-r1 { fill: #c5c8c6 }
-.terminal-1365407539-r2 { fill: #5f87ff }
-.terminal-1365407539-r3 { fill: #5f87af;font-style: italic; }
-.terminal-1365407539-r4 { fill: #5f87af }
-.terminal-1365407539-r5 { fill: #8787ff }
-.terminal-1365407539-r6 { fill: #afafff }
-.terminal-1365407539-r7 { fill: #87afff }
-.terminal-1365407539-r8 { fill: #afafff;font-weight: bold }
-.terminal-1365407539-r9 { fill: #868887 }
-.terminal-1365407539-r10 { fill: #6179a9 }
-.terminal-1365407539-r11 { fill: #6161a9 }
-.terminal-1365407539-r12 { fill: #7979a9;font-weight: bold }
-.terminal-1365407539-r13 { fill: #4961a9 }
+    .terminal-3789971527-r1 { fill: #c5c8c6 }
+.terminal-3789971527-r2 { fill: #5f87ff }
+.terminal-3789971527-r3 { fill: #5f87af;font-style: italic; }
+.terminal-3789971527-r4 { fill: #5f87af }
+.terminal-3789971527-r5 { fill: #8787ff }
+.terminal-3789971527-r6 { fill: #afafff }
+.terminal-3789971527-r7 { fill: #87afff }
+.terminal-3789971527-r8 { fill: #afafff;font-weight: bold }
+.terminal-3789971527-r9 { fill: #868887 }
+.terminal-3789971527-r10 { fill: #6179a9 }
+.terminal-3789971527-r11 { fill: #6161a9 }
+.terminal-3789971527-r12 { fill: #7979a9;font-weight: bold }
+.terminal-3789971527-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-1365407539-clip-terminal">
-      <rect x="0" y="0" width="1414.1999999999998" height="462.59999999999997" />
+    <clipPath id="terminal-3789971527-clip-terminal">
+      <rect x="0" y="0" width="1389.8" height="462.59999999999997" />
     </clipPath>
-    <clipPath id="terminal-1365407539-line-0">
-    <rect x="0" y="1.5" width="1415.2" height="24.65"/>
+    <clipPath id="terminal-3789971527-line-0">
+    <rect x="0" y="1.5" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-1">
-    <rect x="0" y="25.9" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-1">
+    <rect x="0" y="25.9" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-2">
-    <rect x="0" y="50.3" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-2">
+    <rect x="0" y="50.3" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-3">
-    <rect x="0" y="74.7" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-3">
+    <rect x="0" y="74.7" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-4">
-    <rect x="0" y="99.1" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-4">
+    <rect x="0" y="99.1" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-5">
-    <rect x="0" y="123.5" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-5">
+    <rect x="0" y="123.5" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-6">
-    <rect x="0" y="147.9" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-6">
+    <rect x="0" y="147.9" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-7">
-    <rect x="0" y="172.3" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-7">
+    <rect x="0" y="172.3" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-8">
-    <rect x="0" y="196.7" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-8">
+    <rect x="0" y="196.7" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-9">
-    <rect x="0" y="221.1" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-9">
+    <rect x="0" y="221.1" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-10">
-    <rect x="0" y="245.5" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-10">
+    <rect x="0" y="245.5" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-11">
-    <rect x="0" y="269.9" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-11">
+    <rect x="0" y="269.9" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-12">
-    <rect x="0" y="294.3" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-12">
+    <rect x="0" y="294.3" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-13">
-    <rect x="0" y="318.7" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-13">
+    <rect x="0" y="318.7" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-14">
-    <rect x="0" y="343.1" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-14">
+    <rect x="0" y="343.1" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-15">
-    <rect x="0" y="367.5" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-15">
+    <rect x="0" y="367.5" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-16">
-    <rect x="0" y="391.9" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-16">
+    <rect x="0" y="391.9" width="1390.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1365407539-line-17">
-    <rect x="0" y="416.3" width="1415.2" height="24.65"/>
+<clipPath id="terminal-3789971527-line-17">
+    <rect x="0" y="416.3" width="1390.8" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1432" height="511.6" rx="8"/><text class="terminal-1365407539-title" fill="#c5c8c6" text-anchor="middle" x="716" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1407" height="511.6" rx="8"/><text class="terminal-3789971527-title" fill="#c5c8c6" text-anchor="middle" x="703" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1365407539-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3789971527-clip-terminal)">
     
-    <g class="terminal-1365407539-matrix">
-    <text class="terminal-1365407539-r1" x="305" y="20" textLength="329.4" clip-path="url(#terminal-1365407539-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-1365407539-r2" x="646.6" y="20" textLength="146.4" clip-path="url(#terminal-1365407539-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-1365407539-r1" x="1415.2" y="20" textLength="12.2" clip-path="url(#terminal-1365407539-line-0)">
-</text><text class="terminal-1365407539-r1" x="1415.2" y="44.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-1)">
-</text><text class="terminal-1365407539-r3" x="305" y="68.8" textLength="793" clip-path="url(#terminal-1365407539-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-1365407539-r1" x="1415.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-2)">
-</text><text class="terminal-1365407539-r1" x="1415.2" y="93.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-3)">
-</text><text class="terminal-1365407539-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-1365407539-line-4)">Usage:</text><text class="terminal-1365407539-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-1365407539-line-4)">smol</text><text class="terminal-1365407539-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-1365407539-line-4)">-k</text><text class="terminal-1365407539-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-1365407539-line-4)">8s</text><text class="terminal-1365407539-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-1365407539-line-4)">-l</text><text class="terminal-1365407539-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-1365407539-line-4)">ab</text><text class="terminal-1365407539-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1365407539-line-4)">[OPTIONS]</text><text class="terminal-1365407539-r1" x="1415.2" y="117.6" textLength="12.2" clip-path="url(#terminal-1365407539-line-4)">
-</text><text class="terminal-1365407539-r1" x="1415.2" y="142" textLength="12.2" clip-path="url(#terminal-1365407539-line-5)">
-</text><text class="terminal-1365407539-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1365407539-line-6)">╭─</text><text class="terminal-1365407539-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-1365407539-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-1365407539-r6" x="219.6" y="166.4" textLength="1171.2" clip-path="url(#terminal-1365407539-line-6)">────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1365407539-r6" x="1390.8" y="166.4" textLength="24.4" clip-path="url(#terminal-1365407539-line-6)">─╮</text><text class="terminal-1365407539-r1" x="1415.2" y="166.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-6)">
-</text><text class="terminal-1365407539-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-7)">│</text><text class="terminal-1365407539-r6" x="1403" y="190.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-7)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="190.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-7)">
-</text><text class="terminal-1365407539-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-8)">│</text><text class="terminal-1365407539-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-8)">-c</text><text class="terminal-1365407539-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-8)">-</text><text class="terminal-1365407539-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-8)">-c</text><text class="terminal-1365407539-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-1365407539-line-8)">onfig</text><text class="terminal-1365407539-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-1365407539-line-8)">&#160;CONFIG_FILE</text><text class="terminal-1365407539-r1" x="329.4" y="215.2" textLength="646.6" clip-path="url(#terminal-1365407539-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;</text><text class="terminal-1365407539-r6" x="1403" y="215.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-8)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="215.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-8)">
-</text><text class="terminal-1365407539-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1365407539-line-9)">│</text><text class="terminal-1365407539-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-1365407539-line-9)">Defaults&#160;to&#160;</text><text class="terminal-1365407539-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-1365407539-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-1365407539-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-1365407539-line-9)">smol</text><text class="terminal-1365407539-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-1365407539-line-9)">-k</text><text class="terminal-1365407539-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-1365407539-line-9)">8s</text><text class="terminal-1365407539-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-1365407539-line-9)">-l</text><text class="terminal-1365407539-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-1365407539-line-9)">ab</text><text class="terminal-1365407539-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-1365407539-line-9)">/config.yaml</text><text class="terminal-1365407539-r6" x="1403" y="239.6" textLength="12.2" clip-path="url(#terminal-1365407539-line-9)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="239.6" textLength="12.2" clip-path="url(#terminal-1365407539-line-9)">
-</text><text class="terminal-1365407539-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1365407539-line-10)">│</text><text class="terminal-1365407539-r6" x="1403" y="264" textLength="12.2" clip-path="url(#terminal-1365407539-line-10)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="264" textLength="12.2" clip-path="url(#terminal-1365407539-line-10)">
-</text><text class="terminal-1365407539-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-11)">│</text><text class="terminal-1365407539-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-1365407539-line-11)">-D</text><text class="terminal-1365407539-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-11)">-</text><text class="terminal-1365407539-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-1365407539-line-11)">-d</text><text class="terminal-1365407539-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-1365407539-line-11)">elete</text><text class="terminal-1365407539-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-1365407539-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-1365407539-r9" x="329.4" y="288.4" textLength="646.6" clip-path="url(#terminal-1365407539-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1365407539-r6" x="1403" y="288.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-11)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="288.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-11)">
-</text><text class="terminal-1365407539-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-12)">│</text><text class="terminal-1365407539-r6" x="1403" y="312.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-12)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="312.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-12)">
-</text><text class="terminal-1365407539-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-13)">│</text><text class="terminal-1365407539-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-13)">-i</text><text class="terminal-1365407539-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-13)">-</text><text class="terminal-1365407539-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-13)">-i</text><text class="terminal-1365407539-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-1365407539-line-13)">nteractive</text><text class="terminal-1365407539-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-1365407539-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-1365407539-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-1365407539-line-13)">smol</text><text class="terminal-1365407539-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-13)">-k</text><text class="terminal-1365407539-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-13)">8s</text><text class="terminal-1365407539-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-13)">-l</text><text class="terminal-1365407539-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-13)">ab</text><text class="terminal-1365407539-r6" x="1403" y="337.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-13)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="337.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-13)">
-</text><text class="terminal-1365407539-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1365407539-line-14)">│</text><text class="terminal-1365407539-r6" x="1403" y="361.6" textLength="12.2" clip-path="url(#terminal-1365407539-line-14)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="361.6" textLength="12.2" clip-path="url(#terminal-1365407539-line-14)">
-</text><text class="terminal-1365407539-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1365407539-line-15)">│</text><text class="terminal-1365407539-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1365407539-line-15)">-v</text><text class="terminal-1365407539-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-1365407539-line-15)">-</text><text class="terminal-1365407539-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-1365407539-line-15)">-v</text><text class="terminal-1365407539-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-1365407539-line-15)">ersion</text><text class="terminal-1365407539-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-1365407539-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-1365407539-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-1365407539-line-15)">smol</text><text class="terminal-1365407539-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-1365407539-line-15)">-k</text><text class="terminal-1365407539-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-1365407539-line-15)">8s</text><text class="terminal-1365407539-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-1365407539-line-15)">-l</text><text class="terminal-1365407539-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-1365407539-line-15)">ab</text><text class="terminal-1365407539-r9" x="732" y="386" textLength="244" clip-path="url(#terminal-1365407539-line-15)">&#160;(v3.2.2)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1365407539-r6" x="1403" y="386" textLength="12.2" clip-path="url(#terminal-1365407539-line-15)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="386" textLength="12.2" clip-path="url(#terminal-1365407539-line-15)">
-</text><text class="terminal-1365407539-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-16)">│</text><text class="terminal-1365407539-r6" x="1403" y="410.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-16)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="410.4" textLength="12.2" clip-path="url(#terminal-1365407539-line-16)">
-</text><text class="terminal-1365407539-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-17)">│</text><text class="terminal-1365407539-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1365407539-line-17)">-h</text><text class="terminal-1365407539-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-17)">-</text><text class="terminal-1365407539-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1365407539-line-17)">-h</text><text class="terminal-1365407539-r5" x="97.6" y="434.8" textLength="36.6" clip-path="url(#terminal-1365407539-line-17)">elp</text><text class="terminal-1365407539-r1" x="329.4" y="434.8" textLength="646.6" clip-path="url(#terminal-1365407539-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1365407539-r6" x="1403" y="434.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-17)">│</text><text class="terminal-1365407539-r1" x="1415.2" y="434.8" textLength="12.2" clip-path="url(#terminal-1365407539-line-17)">
-</text><text class="terminal-1365407539-r6" x="0" y="459.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-18)">╰─</text><text class="terminal-1365407539-r6" x="24.4" y="459.2" textLength="829.6" clip-path="url(#terminal-1365407539-line-18)">────────────────────────────────────────────────────────────────────</text><text class="terminal-1365407539-r6" x="854" y="459.2" textLength="109.8" clip-path="url(#terminal-1365407539-line-18)">&#160;♥&#160;docs:&#160;</text><text class="terminal-1365407539-r6" x="963.8" y="459.2" textLength="414.8" clip-path="url(#terminal-1365407539-line-18)">github.com/small-hack/smol-k8s-lab</text><text class="terminal-1365407539-r6" x="1390.8" y="459.2" textLength="24.4" clip-path="url(#terminal-1365407539-line-18)">─╯</text><text class="terminal-1365407539-r1" x="1415.2" y="459.2" textLength="12.2" clip-path="url(#terminal-1365407539-line-18)">
+    <g class="terminal-3789971527-matrix">
+    <text class="terminal-3789971527-r1" x="292.8" y="20" textLength="329.4" clip-path="url(#terminal-3789971527-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-3789971527-r2" x="634.4" y="20" textLength="146.4" clip-path="url(#terminal-3789971527-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-3789971527-r1" x="1390.8" y="20" textLength="12.2" clip-path="url(#terminal-3789971527-line-0)">
+</text><text class="terminal-3789971527-r1" x="1390.8" y="44.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-1)">
+</text><text class="terminal-3789971527-r3" x="292.8" y="68.8" textLength="793" clip-path="url(#terminal-3789971527-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-3789971527-r1" x="1390.8" y="68.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-2)">
+</text><text class="terminal-3789971527-r1" x="1390.8" y="93.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-3)">
+</text><text class="terminal-3789971527-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-3789971527-line-4)">Usage:</text><text class="terminal-3789971527-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-3789971527-line-4)">smol</text><text class="terminal-3789971527-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-3789971527-line-4)">-k</text><text class="terminal-3789971527-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-3789971527-line-4)">8s</text><text class="terminal-3789971527-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-3789971527-line-4)">-l</text><text class="terminal-3789971527-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-3789971527-line-4)">ab</text><text class="terminal-3789971527-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-3789971527-line-4)">[OPTIONS]</text><text class="terminal-3789971527-r1" x="1390.8" y="117.6" textLength="12.2" clip-path="url(#terminal-3789971527-line-4)">
+</text><text class="terminal-3789971527-r1" x="1390.8" y="142" textLength="12.2" clip-path="url(#terminal-3789971527-line-5)">
+</text><text class="terminal-3789971527-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-3789971527-line-6)">╭─</text><text class="terminal-3789971527-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-3789971527-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-3789971527-r6" x="219.6" y="166.4" textLength="1146.8" clip-path="url(#terminal-3789971527-line-6)">──────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-3789971527-r6" x="1366.4" y="166.4" textLength="24.4" clip-path="url(#terminal-3789971527-line-6)">─╮</text><text class="terminal-3789971527-r1" x="1390.8" y="166.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-6)">
+</text><text class="terminal-3789971527-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-7)">│</text><text class="terminal-3789971527-r6" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-7)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-7)">
+</text><text class="terminal-3789971527-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-8)">│</text><text class="terminal-3789971527-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-8)">-c</text><text class="terminal-3789971527-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-8)">-</text><text class="terminal-3789971527-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-8)">-c</text><text class="terminal-3789971527-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-3789971527-line-8)">onfig</text><text class="terminal-3789971527-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-3789971527-line-8)">&#160;CONFIG_FILE</text><text class="terminal-3789971527-r1" x="329.4" y="215.2" textLength="646.6" clip-path="url(#terminal-3789971527-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;</text><text class="terminal-3789971527-r6" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-8)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-8)">
+</text><text class="terminal-3789971527-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3789971527-line-9)">│</text><text class="terminal-3789971527-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-3789971527-line-9)">Defaults&#160;to&#160;</text><text class="terminal-3789971527-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-3789971527-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-3789971527-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-3789971527-line-9)">smol</text><text class="terminal-3789971527-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-3789971527-line-9)">-k</text><text class="terminal-3789971527-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-3789971527-line-9)">8s</text><text class="terminal-3789971527-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-3789971527-line-9)">-l</text><text class="terminal-3789971527-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-3789971527-line-9)">ab</text><text class="terminal-3789971527-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-3789971527-line-9)">/config.yaml</text><text class="terminal-3789971527-r6" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-3789971527-line-9)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3789971527-line-9)">
+</text><text class="terminal-3789971527-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3789971527-line-10)">│</text><text class="terminal-3789971527-r6" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-3789971527-line-10)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="264" textLength="12.2" clip-path="url(#terminal-3789971527-line-10)">
+</text><text class="terminal-3789971527-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-11)">│</text><text class="terminal-3789971527-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-3789971527-line-11)">-D</text><text class="terminal-3789971527-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-11)">-</text><text class="terminal-3789971527-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-3789971527-line-11)">-d</text><text class="terminal-3789971527-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-3789971527-line-11)">elete</text><text class="terminal-3789971527-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-3789971527-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-3789971527-r9" x="329.4" y="288.4" textLength="646.6" clip-path="url(#terminal-3789971527-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3789971527-r6" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-11)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-11)">
+</text><text class="terminal-3789971527-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-12)">│</text><text class="terminal-3789971527-r6" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-12)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-12)">
+</text><text class="terminal-3789971527-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-13)">│</text><text class="terminal-3789971527-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-13)">-i</text><text class="terminal-3789971527-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-13)">-</text><text class="terminal-3789971527-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-13)">-i</text><text class="terminal-3789971527-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-3789971527-line-13)">nteractive</text><text class="terminal-3789971527-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-3789971527-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-3789971527-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-3789971527-line-13)">smol</text><text class="terminal-3789971527-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-13)">-k</text><text class="terminal-3789971527-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-13)">8s</text><text class="terminal-3789971527-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-13)">-l</text><text class="terminal-3789971527-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-13)">ab</text><text class="terminal-3789971527-r6" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-13)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-13)">
+</text><text class="terminal-3789971527-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-3789971527-line-14)">│</text><text class="terminal-3789971527-r6" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-3789971527-line-14)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="361.6" textLength="12.2" clip-path="url(#terminal-3789971527-line-14)">
+</text><text class="terminal-3789971527-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-3789971527-line-15)">│</text><text class="terminal-3789971527-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-3789971527-line-15)">-v</text><text class="terminal-3789971527-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-3789971527-line-15)">-</text><text class="terminal-3789971527-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-3789971527-line-15)">-v</text><text class="terminal-3789971527-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-3789971527-line-15)">ersion</text><text class="terminal-3789971527-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-3789971527-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-3789971527-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-3789971527-line-15)">smol</text><text class="terminal-3789971527-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-3789971527-line-15)">-k</text><text class="terminal-3789971527-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-3789971527-line-15)">8s</text><text class="terminal-3789971527-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-3789971527-line-15)">-l</text><text class="terminal-3789971527-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-3789971527-line-15)">ab</text><text class="terminal-3789971527-r9" x="732" y="386" textLength="244" clip-path="url(#terminal-3789971527-line-15)">&#160;(v3.3.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3789971527-r6" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-3789971527-line-15)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="386" textLength="12.2" clip-path="url(#terminal-3789971527-line-15)">
+</text><text class="terminal-3789971527-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-16)">│</text><text class="terminal-3789971527-r6" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-16)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="410.4" textLength="12.2" clip-path="url(#terminal-3789971527-line-16)">
+</text><text class="terminal-3789971527-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-17)">│</text><text class="terminal-3789971527-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-3789971527-line-17)">-h</text><text class="terminal-3789971527-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-17)">-</text><text class="terminal-3789971527-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-3789971527-line-17)">-h</text><text class="terminal-3789971527-r5" x="97.6" y="434.8" textLength="36.6" clip-path="url(#terminal-3789971527-line-17)">elp</text><text class="terminal-3789971527-r1" x="329.4" y="434.8" textLength="646.6" clip-path="url(#terminal-3789971527-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3789971527-r6" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-17)">│</text><text class="terminal-3789971527-r1" x="1390.8" y="434.8" textLength="12.2" clip-path="url(#terminal-3789971527-line-17)">
+</text><text class="terminal-3789971527-r6" x="0" y="459.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-18)">╰─</text><text class="terminal-3789971527-r6" x="24.4" y="459.2" textLength="719.8" clip-path="url(#terminal-3789971527-line-18)">───────────────────────────────────────────────────────────</text><text class="terminal-3789971527-r6" x="744.2" y="459.2" textLength="109.8" clip-path="url(#terminal-3789971527-line-18)">&#160;♥&#160;docs:&#160;</text><text class="terminal-3789971527-r6" x="854" y="459.2" textLength="500.2" clip-path="url(#terminal-3789971527-line-18)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-3789971527-r6" x="1366.4" y="459.2" textLength="24.4" clip-path="url(#terminal-3789971527-line-18)">─╯</text><text class="terminal-3789971527-r1" x="1390.8" y="459.2" textLength="12.2" clip-path="url(#terminal-3789971527-line-18)">
 </text>
     </g>
     </g>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 <h1 align="center">
-🧸 Smol K8s Lab </h1>
+🧸 Smol K8s Lab <a href="https://github.com/jessebot/smol-k8s-lab/releases"><img src="https://img.shields.io/github/v/release/jessebot/smol-k8s-lab?style=plastic&labelColor=484848&color=3CA324&logo=GitHub&logoColor=white"></a></h1>
 
-`smol-k8s-lab` <a href="https://github.com/jessebot/smol-k8s-lab/releases"><img src="https://img.shields.io/github/v/release/jessebot/smol-k8s-lab?style=plastic&labelColor=484848&color=3CA324&logo=GitHub&logoColor=white"></a> leverages Argo CD and slim k8s distributions like K3s to create production-like environments via a declarative workflow. Batteries and 🦑 included.
+`smol-k8s-lab` leverages Argo CD and slim k8s distributions like K3s to create production-like environments via a declarative workflow. Batteries and 🦑 included.
 
 ## About
 
-`smol-k8s-lab`'s declarative workflow enables rapid iteration in production-like environments with minimal costs for failure. This makes it ideal for proof-of-concepts, prototyping, and benchmarking Kubernetes applications and distributions! 💙
+`smol-k8s-lab`'s declarative workflow, CLI, and TUI enable rapid iteration in production-like environments with minimal costs for failure. This makes it ideal for proof-of-concepts, prototyping, and benchmarking Kubernetes applications and distributions! 💙
 
-By default, `smol-k8s-lab` deploys [Argo CD] + [Argo CD Appset Secret Plugin] which enables Argo CD to securely manage your lab via files in open-source Git repos. Additionally, a customized dark-theme is provided for Argo CD's incredibly useful web-interface.
+By default, `smol-k8s-lab` deploys [Argo CD] + [Argo CD Appset Secret Plugin] which enables Argo CD to securely manage your lab via files in open-source Git repos. We can optionally make heavy use of Bitwarden. Additionally, a customized dark-theme is provided for Argo CD's incredibly useful web-interface.
 
 Consider viewing my very long walk through if you like video walk-throughs:
 

--- a/docs/k8s_apps/argocd.md
+++ b/docs/k8s_apps/argocd.md
@@ -38,6 +38,8 @@ apps:
       To disable Appset Secret Plugin, please set directory recursion to false.
 
       Learn more: [link=https://github.com/small-hack/appset-secret-plugin]https://github.com/small-hack/appset-secret-plugin[/link]
+    init:
+      enabled: true
     argo:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:
@@ -58,6 +60,8 @@ apps:
       directory_recursion: true
       # source repos for Argo CD argo-cd Project (in addition to argo_cd.argo.repo)
       project:
+        # you can change this project name :)
+        name: argo-cd
         source_repos:
           - https://argoproj.github.io/argo-helm
           - https://small-hack.github.io/appset-secret-plugin

--- a/docs/k8s_apps/bitwarden_eso_provider.md
+++ b/docs/k8s_apps/bitwarden_eso_provider.md
@@ -59,6 +59,7 @@ apps:
       secret_keys: {}
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: external-secrets-operator
         source_repos:
           - https://charts.external-secrets.io
           # you can remove this one if you're not using bitwarden to store your k8s secrets

--- a/docs/k8s_apps/cert_manager.md
+++ b/docs/k8s_apps/cert_manager.md
@@ -66,6 +66,7 @@ apps:
       directory_recursion: false
       # source repos for cert-manager CD App Project (in addition to argo.repo)
       project:
+        name: cert-manager
         source_repos:
           - https://charts.jetstack.io
         destination:
@@ -130,6 +131,7 @@ apps:
       directory_recursion: false
       # source repos for cert-manager CD App Project (in addition to argo.repo)
       project:
+        name: cert-manager
         source_repos:
           - https://charts.jetstack.io
         destination:

--- a/docs/k8s_apps/cnpg_operator.md
+++ b/docs/k8s_apps/cnpg_operator.md
@@ -30,6 +30,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: cnpg-operator
         source_repos:
         - https://github.com/small-hack/argocd-apps
         - https://cloudnative-pg.github.io/charts

--- a/docs/k8s_apps/experimental/cilium.md
+++ b/docs/k8s_apps/experimental/cilium.md
@@ -23,17 +23,17 @@ apps:
       # git repo to install the Argo CD app from
       repo: "https://github.com/small-hack/argocd-apps"
       # path in the argo repo to point to. Trailing slash very important!
-      path: "alpha/cilium/"
+      path: "demo/cilium/"
       # either the branch or tag to point at in the argo repo above
       ref: "main"
       # namespace to install the k8s app in
       namespace: "cilium"
       # source repos for Argo CD cilium Project
       project:
+        name: cilium
         source_repos:
           - "https://helm.cilium.io/"
         destination:
           namespaces:
-            - argocd
             - cilium
 ```

--- a/docs/k8s_apps/experimental/infisical.md
+++ b/docs/k8s_apps/experimental/infisical.md
@@ -27,13 +27,14 @@ apps:
       # git repo to install the Argo CD app from
       repo: "https://github.com/small-hack/argocd-apps"
       # path in the argo repo to point to. Trailing slash very important!
-      path: "infisical/"
+      path: "demo/infisical/"
       # either the branch or tag to point at in the argo repo above
       ref: "main"
       # namespace to install the k8s app in
       namespace: "infisical"
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: infisical
         source_repos:
           - "registry-1.docker.io"
           - "https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/"

--- a/docs/k8s_apps/experimental/kepler.md
+++ b/docs/k8s_apps/experimental/kepler.md
@@ -2,4 +2,37 @@
 
 This app is still in alpha state as we learn more about how best to configure it. In the meantime, to our knowledge you can start playing with it after installing it alongside [cilium](/k8s_apps/cilium.md).
 
-You can also check out our [Kepler Argo CD Application](https://github.com/small-hack/argocd-apps/tree/main/alpha/kepler).
+You can also check out our [Kepler Argo CD Application](https://github.com/small-hack/argocd-apps/tree/main/demo/kepler).
+
+## Example Configuration
+
+```yaml
+apps:
+  kepler:
+    description: |
+      [link=https://github.com/sustainable-computing-io/kepler]Kepler[/link] (Kubernetes Efficient Power Level Exporter) uses eBPF to probe energy-related system stats and exports them as Prometheus metrics.
+    enabled: false
+    # Initialization of the app through smol-k8s-lab
+    init:
+      enabled: false
+    argo:
+      # secret keys to provide for the argocd secret plugin app, none by default
+      secret_keys: {}
+      # git repo to install the Argo CD app from
+      repo: https://github.com/small-hack/argocd-apps
+      # path in the argo repo to point to. Trailing slash very important!
+      path: demo/kepler/
+      # either the branch or tag to point at in the argo repo above
+      revision: main
+      # namespace to install the k8s app in
+      namespace: kepler
+      # recurse directories in the provided git repo
+      directory_recursion: false
+      # source repos for Argo CD App Project (in addition to argo.repo)
+      project:
+        source_repos:
+        - https://sustainable-computing-io.github.io/kepler-helm-chart
+        destination:
+          # automatically includes the app's namespace and argocd's namespace
+          namespaces: []
+```

--- a/docs/k8s_apps/experimental/minio.md
+++ b/docs/k8s_apps/experimental/minio.md
@@ -1,15 +1,15 @@
 [MinIO](https://min.io/) is a high-performance, S3 compatible object store. It is built for large scale AI/ML, data lake and database workloads. It is software-defined and runs on any cloud or on-premises infrastructure. MinIO is dual-licensed under open source GNU AGPL v3 and a commercial enterprise license. We at `smol-k8s-lab` use only the AGPLv3 stuff :)
 
-We currently consider MinIO to be in an alpha state, but to launch it, you just need to provide a `hostname`.
+We currently consider MinIO to be in a demo state, but to launch it, you'll need to decide between the operator/tenant helm charts, or the vanilla helm chart.
 
-Check out our [MinIO Argo CD Application](https://github.com/small-hack/argocd-apps/tree/main/alpha/minio).
+Check out our [MinIO Argo CD Applications](https://github.com/small-hack/argocd-apps/tree/main/minio).
 
-## Example config
+## Example config for vanilla helm chart
 
 ```yaml
 apps:
   minio:
-    enabled: false
+    enabled: true
     description: |
       MinIO®️ is a high-performance, S3 compatible object store.
 
@@ -19,17 +19,18 @@ apps:
     argo:
       # secrets keys to make available to ArgoCD ApplicationSets
       secret_keys:
-        hostname: "objectstore.dogpics.biz"
+        admin_console_hostname: "objectstore.dogpics.biz"
       # git repo to install the Argo CD app from
       repo: "https://github.com/small-hack/argocd-apps"
       # path in the argo repo to point to. Trailing slash very important!
-      path: "alpha/minio/"
+      path: "minio/vanilla/"
       # either the branch or tag to point at in the argo repo above
       ref: "main"
       # namespace to install the k8s app in
       namespace: "minio"
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: minio
         source_repos:
           - https://github.com/small-hack/argocd-apps
         destination:

--- a/docs/k8s_apps/experimental/postgres_operator.md
+++ b/docs/k8s_apps/experimental/postgres_operator.md
@@ -1,6 +1,6 @@
 We are experimenting with the Zalando PostgeSQL Operator to create postgresql clusters and manage backups to S3. Our main interest here is that they support major version backups. Our main concern is the mutual TLS support.
 
-In the PostgeSQL Operator Backups for S3 are done to local s3 endpoints consistently and to a configurable remote endpoint.
+In the PostgeSQL Operator, backups for S3 are done to local s3 endpoints consistently and to a configurable remote endpoint. You can see more in our [Zalando Postgres Operator Argo CD Application](https://github.com/small-hack/argocd-apps/tree/main/postgres/operators/zalando).
 
 ## Example yaml config
 
@@ -47,6 +47,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: postgres-operator
         source_repos:
         - https://opensource.zalando.com/postgres-operator/charts/postgres-operator
         - https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui

--- a/docs/k8s_apps/external-secrets-operator.md
+++ b/docs/k8s_apps/external-secrets-operator.md
@@ -52,6 +52,7 @@ apps:
       secret_keys: {}
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: external-secrets-operator
         source_repos:
           - https://charts.external-secrets.io
           # you can remove this one if you're not using bitwarden to store your k8s secrets

--- a/docs/k8s_apps/generic_device_plugin.md
+++ b/docs/k8s_apps/generic_device_plugin.md
@@ -16,6 +16,7 @@ apps:
       namespace: kube-system
       directory_recursion: false
       project:
+        name: generic-device-plugin
         source_repos:
           - https://github.com/squat/generic-device-plugin
         destination:

--- a/docs/k8s_apps/home_assistant.md
+++ b/docs/k8s_apps/home_assistant.md
@@ -44,6 +44,7 @@ apps:
       namespace: home-assistant
       directory_recursion: false
       project:
+        name: home-assistant
         source_repos:
           - https://small-hack.github.io/home-assistant-chart
         destination:
@@ -70,6 +71,7 @@ apps:
       namespace: home-assistant
       directory_recursion: false
       project:
+        name:
         source_repos:
           - http://small-hack.github.io/home-assistant-chart
         destination:

--- a/docs/k8s_apps/k8tz.md
+++ b/docs/k8s_apps/k8tz.md
@@ -30,13 +30,14 @@ apps:
       # git repo to install the Argo CD app from
       repo: "https://github.com/small-hack/argocd-apps"
       # path in the argo repo to point to. Trailing slash very important!
-      path: "alpha/k8tz/"
+      path: "k8tz/"
       # either the branch or tag to point at in the argo repo above
       ref: "main"
       # namespace to install the k8s app in
       namespace: "k8tz"
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: k8tz
         source_repos:
           - "https://k8tz.github.io/k8tz/"
         destination:

--- a/docs/k8s_apps/k8up.md
+++ b/docs/k8s_apps/k8up.md
@@ -45,6 +45,7 @@ apps:
       namespace: "k8up"
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: k8up
         source_repos:
           - "https://k8up-io.github.io/k8up"
           - "https://github.com/k8up-io/k8up.git"

--- a/docs/k8s_apps/keycloak.md
+++ b/docs/k8s_apps/keycloak.md
@@ -23,13 +23,14 @@ apps:
       # git repo to install the Argo CD app from
       repo: "https://github.com/small-hack/argocd-apps"
       # path in the argo repo to point to. Trailing slash very important!
-      path: "alpha/keycloak/"
+      path: "demo/keycloak/"
       # either the branch or tag to point at in the argo repo above
       ref: "main"
       # namespace to install the k8s app in
       namespace: "keycloak"
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: keycloak
         source_repos:
           - "registry-1.docker.io"
         destination:

--- a/docs/k8s_apps/mastodon.md
+++ b/docs/k8s_apps/mastodon.md
@@ -111,6 +111,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: mastodon
         # depending on if you use seaweedfs or minio, you can remove the other source repo
         source_repos:
           - registry-1.docker.io

--- a/docs/k8s_apps/matrix.md
+++ b/docs/k8s_apps/matrix.md
@@ -86,6 +86,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: matrix
         source_repos:
           - https://small-hack.github.io/cloudnative-pg-cluster-chart
           - https://small-hack.github.io/matrix-chart

--- a/docs/k8s_apps/metallb.md
+++ b/docs/k8s_apps/metallb.md
@@ -41,6 +41,7 @@ apps:
       namespace: metallb-system
       # source repos for Argo CD metallb Project (in addition to metallb.argo.repo)
       project:
+        name: metallb
         source_repos:
         - https://github.com/metallb/metallb.git
         destination:

--- a/docs/k8s_apps/nextcloud.md
+++ b/docs/k8s_apps/nextcloud.md
@@ -106,6 +106,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: nextcloud
         source_repos:
           - registry-1.docker.io
           - https://nextcloud.github.io/helm

--- a/docs/k8s_apps/seaweedfs.md
+++ b/docs/k8s_apps/seaweedfs.md
@@ -53,6 +53,7 @@ apps:
       directory_recursion: true
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: seaweedfs
         source_repos:
         - https://seaweedfs.github.io/seaweedfs/helm
         - https://seaweedfs.github.io/seaweedfs-csi-driver/helm

--- a/docs/k8s_apps/vouch.md
+++ b/docs/k8s_apps/vouch.md
@@ -60,6 +60,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: vouch
         source_repos:
           - https://jessebot.github.io/vouch-helm-chart
         destination:

--- a/docs/k8s_apps/zitadel.md
+++ b/docs/k8s_apps/zitadel.md
@@ -100,6 +100,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: zitadel
         source_repos:
           - https://charts.zitadel.com
           - https://zitadel.github.io/zitadel-charts

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,5 +1,6 @@
-site_name: smol-k8s-lab
-site_url: https://smol-k8s.com
+site_name: smol-k8s-lab docs
+site_url: https://small-hack.github.io/smol-k8s-lab
+repo_url: https://github.com/small-hack/smol-k8s-lab
 plugins:
   - mkdocs-video
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "3.2.2"
+version       = "3.3.0"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/__init__.py
+++ b/smol_k8s_lab/__init__.py
@@ -77,6 +77,9 @@ def process_log_config(log_dict: dict = {"level": "warn", "file": ""}):
     for handler in logging.root.handlers[:]:
         logging.root.removeHandler(handler)
 
+    kubernetes = logging.getLogger("kubernetes")
+    kubernetes.level = "WARNING"
+
     # this uses the opts dictionary as parameters to logging.basicConfig()
     logging.basicConfig(**opts)
 

--- a/smol_k8s_lab/__init__.py
+++ b/smol_k8s_lab/__init__.py
@@ -337,8 +337,13 @@ def main(config: str = "",
 
         matrix_hostname = SECRETS.get('matrix_hostname', "")
         if matrix_hostname:
-            final_msg += ("\n🗣️ Matrix, for your chat:\n"
+            final_msg += ("\n💬 Matrix, for your chat:\n"
                           f"[blue][link]https://{matrix_hostname}[/][/]\n")
+
+        home_assistant_hostname = SECRETS.get('home_assistant_hostname', "")
+        if home_assistant_hostname:
+            final_msg += ("\n🏠 Home Assistant, for managing your IoT needs:\n"
+                          f"[blue][link]https://{home_assistant_hostname}[/][/]\n")
 
     CONSOLE.print(Panel(final_msg,
                         title='[green]◝(ᵔᵕᵔ)◜ Success!',

--- a/smol_k8s_lab/bitwarden/bw_cli.py
+++ b/smol_k8s_lab/bitwarden/bw_cli.py
@@ -158,15 +158,16 @@ class BwCLI():
         log.debug('New password generated.')
         return password
 
-    def get_item(self, item_name: str) -> list:
+    def get_item(self, item_name: str, sync_first: bool = True) -> list:
         """
         Get Item and return False if it does not exist else return the item ID
 
         Required Args:
             - item_name: str of name of item
         """
-        # always sync the vault before checking anything
-        self.sync()
+        # always sync vault before checking anything, unless otherwise stated
+        if sync_first:
+            self.sync()
 
         # go get the actual item
         response = json.loads(

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -184,6 +184,7 @@ apps:
       directory_recursion: true
       # source repos for Argo CD argo-cd Project (in addition to argo_cd.argo.repo)
       project:
+        name: argo-cd
         source_repos:
           - https://argoproj.github.io/argo-helm
           - https://small-hack.github.io/appset-secret-plugin
@@ -240,6 +241,7 @@ apps:
       directory_recursion: false
       # source repos for cert-manager CD App Project (in addition to argo.repo)
       project:
+        name: cert-manager
         source_repos:
           - https://charts.jetstack.io
         destination:
@@ -271,6 +273,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD cilium Project
       project:
+        name: cilium
         source_repos:
           - "https://helm.cilium.io/"
         destination:
@@ -298,6 +301,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: cnpg-operator
         source_repos:
         - https://github.com/small-hack/argocd-apps
         - https://cloudnative-pg.github.io/charts
@@ -339,6 +343,7 @@ apps:
       secret_keys: {}
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: external-secrets-operator
         source_repos:
           - https://charts.external-secrets.io
           # you can remove this one if you're not using bitwarden to store your k8s secrets
@@ -359,6 +364,7 @@ apps:
       namespace: kube-system
       directory_recursion: false
       project:
+        name: generic-device-plugin
         source_repos:
           - https://github.com/squat/generic-device-plugin
         destination:
@@ -397,6 +403,7 @@ apps:
       namespace: home-assistant
       directory_recursion: false
       project:
+        name: home-assistant
         source_repos:
           - https://small-hack.github.io/home-assistant-chart
         destination:
@@ -429,6 +436,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: infisical
         source_repos:
           - "registry-1.docker.io"
           - "https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/"
@@ -459,6 +467,7 @@ apps:
       secret_keys: {}
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: ingress-nginx
         source_repos:
           - https://charts.jetstack.io
           - "https://kubernetes.github.io/ingress-nginx"
@@ -490,6 +499,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: k8tz
         source_repos:
           - "https://k8tz.github.io/k8tz/"
         destination:
@@ -518,6 +528,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to app.argo.repo)
       project:
+        name: k8up
         source_repos:
           - "https://k8up-io.github.io/k8up"
           - "https://github.com/k8up-io/k8up.git"
@@ -547,6 +558,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: kepler
         source_repos:
           - "https://sustainable-computing-io.github.io/kepler-helm-chart"
         destination:
@@ -575,6 +587,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: kubevirt
         source_repos:
         - https://cloudymax.github.io/kubevirt-community-stack/
         destination:
@@ -608,6 +621,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: kyverno
         source_repos: []
         destination:
           # automatically includes the app's namespace and argocd's namespace
@@ -675,6 +689,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: mastodon
         # depending on if you use seaweedfs or minio, you can remove the other source repo
         source_repos:
           - registry-1.docker.io
@@ -751,6 +766,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: matrix
         source_repos:
           - https://small-hack.github.io/cloudnative-pg-cluster-chart
           - https://small-hack.github.io/matrix-chart
@@ -791,6 +807,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD metallb Project (in addition to metallb.argo.repo)
       project:
+        name: metallb
         source_repos:
           - "https://github.com/metallb/metallb.git"
         destination:
@@ -821,6 +838,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: minio
         source_repos:
           - https://operator.min.io/
         destination:
@@ -860,6 +878,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: minio
         source_repos:
           - https://operator.min.io/
         destination:
@@ -922,6 +941,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: nextcloud
         source_repos:
           - registry-1.docker.io
           - https://nextcloud.github.io/helm
@@ -973,6 +993,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: postgres-operator
         source_repos:
         - https://opensource.zalando.com/postgres-operator/charts/postgres-operator
         - https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui
@@ -1014,6 +1035,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: prometheus
         source_repos:
           - "registry-1.docker.io"
           - "https://github.com/prometheus-community/helm-charts.git"
@@ -1054,6 +1076,7 @@ apps:
       directory_recursion: true
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: seaweedfs
         source_repos:
         - https://seaweedfs.github.io/seaweedfs/helm
         - https://seaweedfs.github.io/seaweedfs-csi-driver/helm
@@ -1085,6 +1108,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: seaweedfs
         source_repos:
         - https://seaweedfs.github.io/seaweedfs-csi-driver/helm
         destination:
@@ -1116,6 +1140,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: vault
         source_repos:
           - https://helm.releases.hashicorp.com
         destination:
@@ -1156,6 +1181,7 @@ apps:
       directory_recursion: false
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: vouch
         source_repos:
           - https://jessebot.github.io/vouch-helm-chart
         destination:
@@ -1237,6 +1263,7 @@ apps:
       directory_recursion: true
       # source repos for Argo CD App Project (in addition to argo.repo)
       project:
+        name: zitadel
         source_repos:
           - https://charts.zitadel.com
           - https://zitadel.github.io/zitadel-charts

--- a/smol_k8s_lab/k8s_apps/identity_provider/vouch.py
+++ b/smol_k8s_lab/k8s_apps/identity_provider/vouch.py
@@ -164,7 +164,7 @@ def configure_vouch(k8s_obj: K8s,
                     )[0]['id']
 
             vouch_id = bitwarden.get_item(
-                    f"vouch-config-{vouch_hostname}"
+                    f"vouch-config-{vouch_hostname}", False
                     )[0]['id']
 
             # update the vouch values for the argocd appset

--- a/smol_k8s_lab/k8s_apps/identity_provider/zitadel.py
+++ b/smol_k8s_lab/k8s_apps/identity_provider/zitadel.py
@@ -198,23 +198,23 @@ def configure_zitadel(k8s_obj: K8s,
                     )[0]['id']
 
             s3_backup_id = bitwarden.get_item(
-                    f"zitadel-backups-s3-credentials-{zitadel_hostname}"
+                    f"zitadel-backups-s3-credentials-{zitadel_hostname}", False
                     )[0]['id']
 
             s3_admin_id = bitwarden.get_item(
-                    f"zitadel-admin-s3-credentials-{zitadel_hostname}"
+                    f"zitadel-admin-s3-credentials-{zitadel_hostname}", False
                     )[0]['id']
 
             s3_id = bitwarden.get_item(
-                    f"zitadel-postgres-s3-credentials-{zitadel_hostname}"
+                    f"zitadel-postgres-s3-credentials-{zitadel_hostname}", False
                     )[0]['id']
 
             core_id = bitwarden.get_item(
-                    f"zitadel-core-key-{zitadel_hostname}"
+                    f"zitadel-core-key-{zitadel_hostname}", False
                     )[0]['id']
 
             argo_oidc_item = bitwarden.get_item(
-                    f"argocd-oidc-credentials-{argocd_hostname}"
+                    f"argocd-oidc-credentials-{argocd_hostname}", False
                     )[0]
 
             argo_client_id = argo_oidc_item['login']['username']

--- a/smol_k8s_lab/k8s_apps/identity_provider/zitadel_api.py
+++ b/smol_k8s_lab/k8s_apps/identity_provider/zitadel_api.py
@@ -488,7 +488,7 @@ class Zitadel():
 
         response = request("GET", url, headers=self.headers, data={},
                            verify=self.verify).json()
-        log.info(response)
+        log.debug(response)
 
         self.user_id = response['user']['id']
         self.resource_owner = response['user']['details']['resourceOwner']

--- a/smol_k8s_lab/k8s_apps/identity_provider/zitadel_api.py
+++ b/smol_k8s_lab/k8s_apps/identity_provider/zitadel_api.py
@@ -158,7 +158,7 @@ class Zitadel():
                 data=payload,
                 verify=self.verify
                 )
-        log.info(response.text)
+        log.debug(response.text)
 
         json_blob = response.json()
         self.project_id = json_blob['id']
@@ -524,8 +524,8 @@ class Zitadel():
         response = request("POST", url, headers=self.headers, data=payload,
                            verify=self.verify)
 
-        log.info(f'response from set_project_by_name for "{project_name}" '
-                 f'_search: {response.text}')
+        log.debug(f'response from set_project_by_name for "{project_name}" '
+                  f'_search: {response.text}')
 
         self.project_id = response.json()['result'][0]['id']
         log.debug(f"zitadel api: set project id to {self.project_id}")

--- a/smol_k8s_lab/k8s_apps/initial_special.py
+++ b/smol_k8s_lab/k8s_apps/initial_special.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3.11
+"""
+       Name: base_install
+DESCRIPTION: installs helm repos, updates them, and installs charts for metallb,
+             cert-manager, and ingress-nginx
+     AUTHOR: @jessebot
+    LICENSE: GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+"""
+import logging as log
+from rich.prompt import Prompt
+from ..bitwarden.bw_cli import BwCLI
+from ..k8s_tools.helm import prepare_helm
+from ..k8s_tools.k8s_lib import K8s
+from ..utils.rich_cli.console_logging import header
+from .argocd import configure_argocd
+from .ingress.ingress_nginx_controller import (configure_ingress_nginx,
+                                               install_ingress_nginx_argocd_app)
+from .ingress.cert_manager import configure_cert_manager
+# from .identity_provider.keycloak import configure_keycloak
+from .identity_provider.zitadel import configure_zitadel
+from .identity_provider.zitadel_api import Zitadel
+from .identity_provider.vouch import configure_vouch
+from .networking.metallb import configure_metallb
+from .networking.cilium import configure_cilium
+from .secrets_management.external_secrets_operator import configure_external_secrets
+from .secrets_management.infisical import configure_infisical
+from .secrets_management.vault import configure_vault
+from .social.matrix import configure_matrix
+from .social.mastodon import configure_mastodon
+from .social.nextcloud import configure_nextcloud
+
+
+def setup_k8s_secrets_management(k8s_obj: K8s,
+                                 k8s_distro: str,
+                                 eso_dict: dict = {},
+                                 eso_provider: str = "",
+                                 infisical_dict: dict = {},
+                                 vault_dict: dict = {},
+                                 bitwarden: BwCLI = None) -> None:
+    """
+    sets up k8s secrets management tooling
+    """
+    # secrets management section
+    header_msg = "Setting up K8s secret management with [green]"
+
+    # setup external secrets operator and bitwarden external secrets
+    if eso_dict['enabled']:
+        header_msg += f'External Secrets Operator[/] and [blue]{eso_provider}[/] as the Provider'
+        header(header_msg, '🤫')
+        configure_external_secrets(k8s_obj,
+                                   eso_dict,
+                                   eso_provider,
+                                   k8s_distro,
+                                   bitwarden)
+
+    # setup infisical - an secrets manager and operator for k8s that replaces eso
+    elif infisical_dict['enabled']:
+        header_msg += 'Infisical Secrets Operator[/]'
+        header(header_msg, '🤫')
+        configure_infisical(k8s_obj, infisical_dict)
+
+    # setup hashicorp's vault, a secret key management system that works with eso
+    if vault_dict['enabled']:
+        configure_vault(k8s_obj, vault_dict)
+
+
+def setup_oidc_provider(k8s_obj: K8s,
+                        api_tls_verify: bool = False,
+                        zitadel_dict: dict = {},
+                        vouch_dict: dict = {},
+                        bw: BwCLI = None,
+                        argocd_fqdn: str = "") -> Zitadel | None:
+    """
+    sets up oidc provider. only zitadel is supported right now
+    if we choose to add keycloak back, we'll be adding the following arg
+    keycloak_dict: dict = {}
+    """
+    header("Setting up [green]OIDC[/]/[green]Oauth[/] Applications")
+
+    # keycloak_enabled = keycloak_dict['enabled']
+    zitadel_enabled = zitadel_dict['enabled']
+
+    vouch_enabled = False
+    if vouch_dict:
+        vouch_enabled = vouch_dict['enabled']
+
+    # setup keycloak if we're using that for OIDC
+    # if keycloak_enabled:
+    #     log.debug("Setting up keycloak")
+    #     configure_keycloak(k8s_obj, keycloak_dict, bw)
+    #     realm = keycloak_dict['argo']['secret_keys']['default_realm']
+    #     user = keycloak_dict['init']['values']['username']
+
+    # setup zitadel if we're using that for OIDC
+    if zitadel_enabled:
+        zitadel_init_enabled = zitadel_dict['init']['enabled']
+        log.debug("Setting up zitadel")
+        if zitadel_init_enabled:
+            zitadel_obj = configure_zitadel(
+                    k8s_obj=k8s_obj,
+                    config_dict=zitadel_dict,
+                    api_tls_verify=api_tls_verify,
+                    argocd_hostname=argocd_fqdn,
+                    bitwarden=bw
+                    )
+        else:
+            configure_zitadel(k8s_obj=k8s_obj,
+                              config_dict=zitadel_dict,
+                              bitwarden=bw)
+
+    if vouch_enabled:
+        log.debug("Setting up vouch")
+        # if keycloak_enabled:
+        #     keycloak_host = keycloak_dict['argo']['secret_keys']['hostname']
+        #     configure_vouch(
+        #        k8s_obj=k8s_obj,
+        #        vouch_config_dict=vouch_dict,
+        #        oidc_provider_name='keycloak',
+        #        oidc_provider_hostname=keycloak_host,
+        #        bitwarden=bw,
+        #        users=[{'user': user}],
+        #        realm=realm)
+        if zitadel_enabled:
+            configure_vouch(k8s_obj=k8s_obj,
+                            vouch_config_dict=vouch_dict,
+                            oidc_provider_name='zitadel',
+                            oidc_provider_hostname=zitadel_dict['argo']['secret_keys']['hostname'],
+                            bitwarden=bw,
+                            users=[],
+                            realm="",
+                            zitadel=zitadel_obj)
+        else:
+            configure_vouch(k8s_obj, vouch_dict, '', '', bw)
+
+    if zitadel_enabled and zitadel_init_enabled:
+        return zitadel_obj
+
+
+def setup_base_apps(k8s_obj: K8s,
+                    k8s_distro: str,
+                    cilium_dict: dict = {},
+                    metallb_dict: dict = {},
+                    ingress_dict: dict = {},
+                    cert_manager_dict: dict = {},
+                    argo_enabled: bool = False,
+                    argo_secrets_plugin_enabled: bool = False,
+                    plugin_secrets: dict = {},
+                    bw: BwCLI = None) -> None:
+    """ 
+    Uses Helm to install all base apps that need to be running being argo cd:
+        cilium, metallb, ingess-nginx, cert-manager, argo cd, argocd secrets plugin
+    All Needed for getting Argo CD up and running.
+    """
+    metallb_enabled = metallb_dict['enabled']
+    cilium_enabled = cilium_dict['enabled']
+    ingress_nginx_enabled = ingress_dict["enabled"]
+    # make sure helm is installed and the repos are up to date
+    prepare_helm(k8s_distro, argo_enabled, metallb_enabled, cilium_enabled,
+                 argo_secrets_plugin_enabled)
+
+    # needed for network policy editor and hubble UI
+    if cilium_enabled:
+        header("Installing [green]cilium[/green] so we have networking tools",
+               '🛜')
+        if cilium_dict['init']['enabled']:
+            configure_cilium(cilium_dict)
+
+    # needed for metal (non-cloud provider) installs
+    if metallb_enabled:
+        header("Installing [green]metallb[/green] so we have an IP address pool",
+               '🛜')
+        if metallb_dict['init']['enabled']:
+            cidr = metallb_dict['init']['values']['address_pool']
+            if not cidr:
+                m = "[green]Please enter a comma seperated list of IPs or CIDRs"
+                cidr = Prompt.ask(m).split(',')
+
+            configure_metallb(k8s_obj, cidr)
+
+    # ingress controller: so we can accept traffic from outside the cluster
+    if ingress_nginx_enabled:
+        # nginx just because that's most supported, treafik support may be added later
+        header("Installing [green]ingress-nginx-controller[/green] to access web"
+               " apps outside the cluster", "🌐")
+        configure_ingress_nginx(k8s_obj, k8s_distro)
+
+    # manager SSL/TLS certificates via lets-encrypt
+    header("Installing [green]cert-manager[/green] for TLS certificates...", '📜')
+    if cert_manager_dict["enabled"]:
+        configure_cert_manager(k8s_obj, cert_manager_dict['init'])
+
+    # then we install argo cd if it's enabled
+    if argo_enabled:
+        configure_argocd(k8s_obj,
+                         bw, 
+                         argo_secrets_plugin_enabled,
+                         plugin_secrets)
+
+    if ingress_nginx_enabled and argo_enabled:
+        install_ingress_nginx_argocd_app(k8s_obj, ingress_dict)
+
+
+def setup_federated_apps(k8s_obj: K8s,
+                         api_tls_verify: bool = False,
+                         nextcloud_dict: dict = {},
+                         mastodon_dict: dict = {},
+                         matrix_dict: dict = {},
+                         zitadel_hostname: str = "",
+                         zitadel_obj: Zitadel = None,
+                         bw: BwCLI = None) -> None:
+    """
+    Setup any federated apps with initialization supported
+    """
+    if nextcloud_dict['enabled']:
+        configure_nextcloud(k8s_obj, nextcloud_dict, bw, zitadel_obj)
+
+    if mastodon_dict['enabled']:
+        configure_mastodon(k8s_obj, mastodon_dict, bw)
+
+    if matrix_dict['enabled']:
+        configure_matrix(k8s_obj, matrix_dict, zitadel_obj, bw)

--- a/smol_k8s_lab/k8s_apps/operators/postgres_operators.py
+++ b/smol_k8s_lab/k8s_apps/operators/postgres_operators.py
@@ -87,11 +87,11 @@ def configure_postgres_operator(k8s_obj: K8s,
                     )[0]['id']
 
             s3_id = bw.get_item(
-                    f"postgres-operator-user-s3-credentials-{hostname}"
+                    f"postgres-operator-user-s3-credentials-{hostname}", False
                     )[0]['id']
 
             s3_backups_id = bw.get_item(
-                    f"postgres-operator-backups-s3-credentials-{hostname}"
+                    f"postgres-operator-backups-s3-credentials-{hostname}", False
                     )[0]['id']
 
             update_argocd_appset_secret(

--- a/smol_k8s_lab/k8s_apps/social/mastodon.py
+++ b/smol_k8s_lab/k8s_apps/social/mastodon.py
@@ -280,35 +280,35 @@ def configure_mastodon(k8s_obj: K8s,
                     )[0]['id']
 
             elastic_id = bitwarden.get_item(
-                    f"mastodon-elasticsearch-credentials-{mastodon_hostname}"
+                    f"mastodon-elasticsearch-credentials-{mastodon_hostname}", False
                     )[0]['id']
 
             redis_id = bitwarden.get_item(
-                    f"mastodon-redis-credentials-{mastodon_hostname}"
+                    f"mastodon-redis-credentials-{mastodon_hostname}", False
                     )[0]['id']
 
             smtp_id = bitwarden.get_item(
-                    f"mastodon-smtp-credentials-{mastodon_hostname}"
+                    f"mastodon-smtp-credentials-{mastodon_hostname}", False
                     )[0]['id']
 
             s3_admin_id = bitwarden.get_item(
-                    f"mastodon-admin-s3-credentials-{mastodon_hostname}"
+                    f"mastodon-admin-s3-credentials-{mastodon_hostname}", False
                     )[0]['id']
 
             s3_db_id = bitwarden.get_item(
-                    f"mastodon-postgres-s3-credentials-{mastodon_hostname}"
+                    f"mastodon-postgres-s3-credentials-{mastodon_hostname}", False
                     )[0]['id']
 
             s3_id = bitwarden.get_item(
-                    f"mastodon-user-s3-credentials-{mastodon_hostname}"
+                    f"mastodon-user-s3-credentials-{mastodon_hostname}", False
                     )[0]['id']
 
             s3_backups_id = bitwarden.get_item(
-                    f"mastodon-backups-s3-credentials-{mastodon_hostname}"
+                    f"mastodon-backups-s3-credentials-{mastodon_hostname}", False
                     )[0]['id']
 
             secrets_id = bitwarden.get_item(
-                    f"mastodon-server-secrets-{mastodon_hostname}"
+                    f"mastodon-server-secrets-{mastodon_hostname}", False
                     )[0]['id']
 
             # {'mastodon_admin_credentials_bitwarden_id': admin_id,

--- a/smol_k8s_lab/k8s_apps/social/matrix.py
+++ b/smol_k8s_lab/k8s_apps/social/matrix.py
@@ -18,8 +18,8 @@ def configure_matrix(k8s_obj: K8s,
     """
     creates a matrix app and initializes it with secrets if you'd like :)
     """
-    header("Setting up [green]Matrix[/green], so you can self host your own chat"
-           '🔢')
+    header("Setting up [green]Matrix[/green], so you can self host your own chat "
+           '💬')
 
     app_installed = check_if_argocd_app_exists('matrix')
     secrets = config_dict['argo']['secret_keys']

--- a/smol_k8s_lab/k8s_apps/social/matrix.py
+++ b/smol_k8s_lab/k8s_apps/social/matrix.py
@@ -229,31 +229,31 @@ def configure_matrix(k8s_obj: K8s,
                     )[0]['id']
 
             smtp_id = bitwarden.get_item(
-                    f"matrix-smtp-credentials-{matrix_hostname}"
+                    f"matrix-smtp-credentials-{matrix_hostname}", False
                     )[0]['id']
 
             s3_admin_id = bitwarden.get_item(
-                    f"matrix-admin-s3-credentials-{matrix_hostname}"
+                    f"matrix-admin-s3-credentials-{matrix_hostname}", False
                     )[0]['id']
 
             s3_db_id = bitwarden.get_item(
-                    f"matrix-postgres-s3-credentials-{matrix_hostname}"
+                    f"matrix-postgres-s3-credentials-{matrix_hostname}", False
                     )[0]['id']
 
             s3_id = bitwarden.get_item(
-                    f"matrix-user-s3-credentials-{matrix_hostname}"
+                    f"matrix-user-s3-credentials-{matrix_hostname}", False
                     )[0]['id']
 
             s3_backups_id = bitwarden.get_item(
-                    f"matrix-backups-s3-credentials-{matrix_hostname}"
+                    f"matrix-backups-s3-credentials-{matrix_hostname}", False
                     )[0]['id']
 
             db_id = bitwarden.get_item(
-                    f"matrix-pgsql-credentials-{matrix_hostname}"
+                    f"matrix-pgsql-credentials-{matrix_hostname}", False
                     )[0]['id']
 
             oidc_id = bitwarden.get_item(
-                    f"matrix-oidc-credentials-{matrix_hostname}"
+                    f"matrix-oidc-credentials-{matrix_hostname}", False
                     )[0]
 
             # identity provider name and id are nested in the oidc item fields

--- a/smol_k8s_lab/k8s_apps/social/nextcloud.py
+++ b/smol_k8s_lab/k8s_apps/social/nextcloud.py
@@ -248,35 +248,35 @@ def configure_nextcloud(k8s_obj: K8s,
                     )[0]['id']
 
             admin_id = bitwarden.get_item(
-                    f"nextcloud-admin-credentials-{nextcloud_hostname}"
+                    f"nextcloud-admin-credentials-{nextcloud_hostname}", False
                     )[0]['id']
 
             smtp_id = bitwarden.get_item(
-                    f"nextcloud-smtp-credentials-{nextcloud_hostname}"
+                    f"nextcloud-smtp-credentials-{nextcloud_hostname}", False
                     )[0]['id']
 
             db_id = bitwarden.get_item(
-                    f"nextcloud-pgsql-credentials-{nextcloud_hostname}"
+                    f"nextcloud-pgsql-credentials-{nextcloud_hostname}", False
                     )[0]['id']
 
             redis_id = bitwarden.get_item(
-                    f"nextcloud-redis-credentials-{nextcloud_hostname}"
+                    f"nextcloud-redis-credentials-{nextcloud_hostname}", False
                     )[0]['id']
 
             s3_admin_id = bitwarden.get_item(
-                    f"nextcloud-admin-s3-credentials-{nextcloud_hostname}"
+                    f"nextcloud-admin-s3-credentials-{nextcloud_hostname}", False
                     )[0]['id']
 
             s3_db_id = bitwarden.get_item(
-                    f"nextcloud-postgres-s3-credentials-{nextcloud_hostname}"
+                    f"nextcloud-postgres-s3-credentials-{nextcloud_hostname}", False
                     )[0]['id']
 
             s3_id = bitwarden.get_item(
-                    f"nextcloud-user-s3-credentials-{nextcloud_hostname}"
+                    f"nextcloud-user-s3-credentials-{nextcloud_hostname}", False
                     )[0]['id']
 
             s3_backups_id = bitwarden.get_item(
-                    f"nextcloud-backups-s3-credentials-{nextcloud_hostname}"
+                    f"nextcloud-backups-s3-credentials-{nextcloud_hostname}", False
                     )[0]['id']
 
             update_argocd_appset_secret(

--- a/smol_k8s_lab/k8s_tools/argocd_util.py
+++ b/smol_k8s_lab/k8s_tools/argocd_util.py
@@ -46,6 +46,7 @@ def install_with_argocd(k8s_obj: K8s, app: str, argo_dict: dict) -> None:
     extra_source_repos = argo_dict["project"].get('source_repos', [])
     if extra_source_repos:
         source_repos.extend(extra_source_repos)
+
     create_argocd_project(k8s_obj,
                           argo_dict['project'].get('name', app),
                           app,

--- a/smol_k8s_lab/k8s_tools/argocd_util.py
+++ b/smol_k8s_lab/k8s_tools/argocd_util.py
@@ -46,7 +46,11 @@ def install_with_argocd(k8s_obj: K8s, app: str, argo_dict: dict) -> None:
     extra_source_repos = argo_dict["project"].get('source_repos', [])
     if extra_source_repos:
         source_repos.extend(extra_source_repos)
-    create_argocd_project(k8s_obj, app, app, set(proj_namespaces), source_repos)
+    create_argocd_project(k8s_obj,
+                          argo_dict['project'].get('name', app),
+                          app,
+                          set(proj_namespaces),
+                          set(source_repos))
 
     cmd = (f"argocd app create {app} --upsert "
            f"--repo {repo} "
@@ -89,8 +93,8 @@ def wait_for_argocd_app(app: str, retry: bool = False) -> None:
 def create_argocd_project(k8s_obj: K8s,
                           project_name: str,
                           app: str,
-                          namespaces: str,
-                          source_repos: list) -> True:
+                          namespaces: set,
+                          source_repos: set) -> True:
     """
     create an argocd project
     """

--- a/smol_k8s_lab/k8s_tools/argocd_util.py
+++ b/smol_k8s_lab/k8s_tools/argocd_util.py
@@ -38,6 +38,8 @@ def install_with_argocd(k8s_obj: K8s, app: str, argo_dict: dict) -> None:
     app_namespace = argo_dict['namespace']
     proj_namespaces = argo_dict['project']['destination']['namespaces']
     proj_namespaces.append(app_namespace)
+    if 'argocd' not in proj_namespaces:
+        proj_namespaces.append('argocd')
 
     # make sure the namespace already exists
     k8s_obj.create_namespace(app_namespace)
@@ -114,13 +116,7 @@ def create_argocd_project(k8s_obj: K8s,
                 }
             ],
             "description": f"project for {app}",
-            "destinations": [
-                {
-                    "name": "in-cluster",
-                    "namespace": 'argocd',
-                    "server": "https://kubernetes.default.svc"
-                }
-            ],
+            "destinations": [],
             "namespaceResourceWhitelist": [
                 {
                     "group": "*",
@@ -128,7 +124,7 @@ def create_argocd_project(k8s_obj: K8s,
                 }
             ],
             "orphanedResources": {},
-            "sourceRepos": source_repos
+            "sourceRepos": list(source_repos)
         },
         "status": {}
     }

--- a/smol_k8s_lab/k8s_tools/k8s_lib.py
+++ b/smol_k8s_lab/k8s_tools/k8s_lib.py
@@ -23,6 +23,7 @@ class K8s():
         This is mostly for storing the k8s config
         """
         config.load_kube_config()
+        client.rest.logger.setLevel(log.WARNING)
         self.api_client = client.ApiClient()
         self.core_v1_api = client.CoreV1Api(self.api_client)
 
@@ -65,6 +66,7 @@ class K8s():
         except ApiException as e:
             log.error("Exception when calling "
                       f"CoreV1Api->create_namespaced_secret: {e}")
+
             # delete the secret if it already exists
             try:
                 self.core_v1_api.delete_namespaced_secret(name, namespace)
@@ -80,7 +82,8 @@ class K8s():
         """
         log.debug(f"Getting secret: {name} in namespace: {namespace}")
 
-        res = subproc([f"kubectl get secret -n {namespace} {name} -o json"])
+        res = subproc([f"kubectl get secret -n {namespace} {name} -o json"],
+                      quiet=True)
         return loads(res)
 
     def delete_secret(self, name: str, namespace: str) -> None:

--- a/smol_k8s_lab/utils/rich_cli/help_text.py
+++ b/smol_k8s_lab/utils/rich_cli/help_text.py
@@ -124,8 +124,8 @@ class RichCommand(click.Command):
 
             options_table.add_row(opt1, opt2, highlighter(help))
 
-        url = ("♥ docs: [link=https://github.com/smal-hack/smol-k8s-lab]"
-               "github.com/small-hack/smol-k8s-lab[/link]")
+        url = ("♥ docs: [link=https://smal-hack.github.io/smol-k8s-lab]"
+               "https://smal-hack.github.io/smol-k8s-lab[/link]")
         console.print(Panel(options_table,
                             border_style="light_steel_blue",
                             title="ʕ ᵔᴥᵔʔ Options",

--- a/smol_k8s_lab/utils/rich_cli/help_text.py
+++ b/smol_k8s_lab/utils/rich_cli/help_text.py
@@ -124,8 +124,8 @@ class RichCommand(click.Command):
 
             options_table.add_row(opt1, opt2, highlighter(help))
 
-        url = ("♥ docs: [link=https://smal-hack.github.io/smol-k8s-lab]"
-               "https://smal-hack.github.io/smol-k8s-lab[/link]")
+        url = ("♥ docs: [link=https://small-hack.github.io/smol-k8s-lab]"
+               "https://small-hack.github.io/smol-k8s-lab[/link]")
         console.print(Panel(options_table,
                             border_style="light_steel_blue",
                             title="ʕ ᵔᴥᵔʔ Options",


### PR DESCRIPTION
- you can now set `argo.project.name` via the config.yaml for each app or via the apps screen in the TUI
- github link appears in doc website
- fix kubernetes logging to only log warnings/errors by default
- fix zitadel logging to not log ever api call output unless debug is on
- add home assistant to final block of links
- don't sync EVERY time we get something from bitwarden
- fix help text docs link