### PR TITLE
Fix netmaker secrets and zitadel app as well as add initial netmaker doc

### DIFF
--- a/docs/k8s_apps/experimental/netmaker.md
+++ b/docs/k8s_apps/experimental/netmaker.md
@@ -1,0 +1,44 @@
+## Netmaker Argo CD Application
+[Netmaker](https://www.netmaker.io/) is a vpn management tool wrapping WireGuard ®️.
+
+
+
+## Example Config
+
+```yaml
+apps:
+  netmaker:
+    enabled: false
+    description: |
+      [link=https://www.netmaker.io/]Netmaker[/link]®️  makes networks with WireGuard. Netmaker automates fast, secure, and distributed virtual networks.
+    init:
+      enabled: true
+      values:
+        user: admin
+    argo:
+      # secrets keys to make available to Argo CD ApplicationSets
+      secret_keys:
+        hostname: netmaker.example.com
+        admin_hostname: admin.netmaker.example.com
+        api_hostname: api.netmaker.example.com
+        broker_hostname: broker.netmaker.example.com
+        auth_provider: oidc
+      # git repo to install the Argo CD app from
+      repo: https://github.com/small-hack/argocd-apps
+      # path in the argo repo to point to. Trailing slash very important!
+      path: demo/netmaker/app_of_apps/
+      # either the branch or tag to point at in the argo repo above
+      revision: main
+      # namespace to install the k8s app in
+      namespace: netmaker
+      # recurse directories in the provided git repo
+      directory_recursion: false
+      # source repos for Argo CD App Project (in addition to argo.repo)
+      project:
+        source_repos:
+        - https://github.com/small-hack/netmaker-helm
+        - https://small-hack.github.io/netmaker-helm
+        destination:
+          # automatically includes the app's namespace and argocd's namespace
+          namespaces: []
+```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -88,6 +88,7 @@ nav:
       - Kyverno: k8s_apps/experimental/kyverno.md
       - Kubevirt: k8s_apps/experimental/kubevirt.md
       - Longhorn: k8s_apps/experimental/longhorn.md
+      - Netmaker: k8s_apps/experimental/netmaker.md
       - MinIO: k8s_apps/experimental/minio.md
       - Zalando Postgress Operator: k8s_apps/experimental/postgres_operator.md
     - Generic Device Plugin: k8s_apps/generic_device_plugin.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "3.4.0"
+version       = "3.5.0"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/__init__.py
+++ b/smol_k8s_lab/__init__.py
@@ -359,7 +359,7 @@ def main(config: str = "",
             final_msg += ("\n🏠 Home Assistant, for managing your IoT needs:\n"
                           f"[blue][link]https://{home_assistant_hostname}[/][/]\n")
 
-        netmaker_hostname = SECRETS.get('netmaker_hostname', "")
+        netmaker_hostname = SECRETS.get('netmaker_admin_panel_url', "")
         if home_assistant_hostname:
             final_msg += ("\n🛜 Netmaker, for managing your own VPN:\n"
                           f"[blue][link]https://{netmaker_hostname}[/][/]\n")

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -925,9 +925,9 @@ apps:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:
         hostname: netmaker.example.com
-        admin_pannel_url: admin.netmaker.example.com
-        api_endpoint_url: api.netmaker.example.com
-        broker_endpoint_url: broker.netmaker.example.com
+        admin_hostname: admin.netmaker.example.com
+        api_hostname: api.netmaker.example.com
+        broker_hostname: broker.netmaker.example.com
         auth_provider: oidc
       # git repo to install the Argo CD app from
       repo: https://github.com/small-hack/argocd-apps

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -927,6 +927,7 @@ apps:
         hostname: netmaker.example.com
         admin_pannel_url: admin.netmaker.example.com
         api_endpoint_url: api.netmaker.example.com
+        broker_endpoint_url: broker.netmaker.example.com
         auth_provider: oidc
       # git repo to install the Argo CD app from
       repo: https://github.com/small-hack/argocd-apps

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -916,7 +916,7 @@ apps:
   netmaker:
     enabled: false
     description: |
-      [link=https://www.netmaker.io/]NetMaker[/link]®️  makes networks with WireGuard. Netmaker automates fast, secure, and distributed virtual networks.
+      [link=https://www.netmaker.io/]Netmaker[/link]®️  makes networks with WireGuard. Netmaker automates fast, secure, and distributed virtual networks.
     init:
       enabled: true
       values:

--- a/smol_k8s_lab/k8s_apps/networking/netmaker.py
+++ b/smol_k8s_lab/k8s_apps/networking/netmaker.py
@@ -54,7 +54,7 @@ def configure_netmaker(k8s_obj: K8s,
 
         # if using bitwarden, put the secret in bitarden and ESO will grab it
         if bitwarden:
-            fields = [create_custom_field("issuer", auth_dict['auth_url'])]
+            fields = [create_custom_field("issuer", f"https://{oidc_provider_hostname}")]
 
             log.debug(f"netmaker oauth fields are {fields}")
             
@@ -111,7 +111,7 @@ def configure_netmaker(k8s_obj: K8s,
                                   'netmaker',
                                   {'CLIENT_ID': auth_dict['client_id'],
                                    'CLIENT_SECRET': auth_dict['client_secret'],
-                                   'OIDC_SSUER': auth_dict['auth_url']}
+                                   'OIDC_SSUER': f"https://{oidc_provider_hostname}"}
                                    )
 
             # create mqtt k8s secret

--- a/smol_k8s_lab/k8s_apps/networking/netmaker.py
+++ b/smol_k8s_lab/k8s_apps/networking/netmaker.py
@@ -59,8 +59,10 @@ def configure_netmaker(k8s_obj: K8s,
             log.debug(f"netmaker oauth fields are {fields}")
             
             postgres_fields = [
+                create_custom_field("host", 'postgresql.svc.cluster.local'),
+                create_custom_field("port", '5432'),
+                create_custom_field("database", 'netmaker'),
                 create_custom_field("postgres_password", postgresPassword),
-                create_custom_field("SQL_PASS", sqlPass)
                 ]
             
             log.info(f"netmaker postgres fields are {postgres_fields}")
@@ -84,6 +86,8 @@ def configure_netmaker(k8s_obj: K8s,
             # create the postgres bitwarden item
             postgres_id = bitwarden.create_login(
                     name=f"{netmaker_hostname}-netmaker-pgsql-credentials",
+                    user='netmaker',
+                    password=sqlPass,
                     fields=postgres_fields
                     )
 

--- a/smol_k8s_lab/k8s_apps/networking/netmaker.py
+++ b/smol_k8s_lab/k8s_apps/networking/netmaker.py
@@ -1,5 +1,4 @@
 import logging as log
-from rich.prompt import Prompt
 from smol_k8s_lab.bitwarden.bw_cli import BwCLI, create_custom_field
 from smol_k8s_lab.k8s_apps.identity_provider.zitadel_api import Zitadel
 from smol_k8s_lab.k8s_tools.argocd_util import (install_with_argocd,
@@ -80,7 +79,7 @@ def configure_netmaker(k8s_obj: K8s,
 
             # create oauth OIDC bitwarden item
             oauth_id = bitwarden.create_login(
-                name='netmaker-oauth-config',
+                name=f'{netmaker_hostname}-netmaker-oauth-config',
                 user=auth_dict['client_id'],
                 item_url=netmaker_hostname,
                 password=auth_dict['client_secret'],
@@ -89,7 +88,7 @@ def configure_netmaker(k8s_obj: K8s,
             
             # create the postgres bitwarden item
             postgres_id = bitwarden.create_login(
-                    name=f"netmaker-pgsql-credentials",
+                    name=f"{netmaker_hostname}-netmaker-pgsql-credentials",
                     fields=postgres_fields
                     )
 
@@ -147,12 +146,12 @@ def configure_netmaker(k8s_obj: K8s,
         if netmaker_config_dict['init']['enabled'] and bitwarden:
             log.debug("Updating netmaker-oath-config bitwarden ID in the appset secret")
             oauth_id = bitwarden.get_item(
-                    f"netmaker-oauth-config-{netmaker_hostname}"
+                    f"{netmaker_hostname}-netmaker-oauth-config"
                     )[0]['id']
 
             log.debug("Updating netmaker-pqsql-credentials bitwarden ID in the appset secret")
             postgres_id = bitwarden.get_item(
-                    f"netmaker-pgsql-credentials"
+                    f"{netmaker_hostname}-netmaker-pgsql-credentials"
                     )[0]['id']
 
             # update the netmaker values for the argocd appset

--- a/smol_k8s_lab/k8s_apps/networking/netmaker.py
+++ b/smol_k8s_lab/k8s_apps/networking/netmaker.py
@@ -38,12 +38,14 @@ def configure_netmaker(k8s_obj: K8s,
         netmaker_hostname = secrets['hostname']
 
     if netmaker_config_dict['init']['enabled'] and not app_installed:
+        netmaker_user = netmaker_config_dict['init']['values']['user']
+        netmaker_realm = netmaker_config_dict['init']['values'].get('realm', "")
         auth_dict = create_netmaker_app(provider=oidc_provider_name,
-                                     provider_hostname=oidc_provider_hostname,
-                                     netmaker_hostname=netmaker_hostname,
-                                     users=netmaker_config_dict['init']['values']['user'],
-                                     zitadel=zitadel,
-                                     realm=netmaker_config_dict['init']['values'].get('realm', ""))
+                                        provider_hostname=oidc_provider_hostname,
+                                        netmaker_hostname=netmaker_hostname,
+                                        users=netmaker_user,
+                                        zitadel=zitadel,
+                                        realm=netmaker_realm)
 
         # generate postgres and mqtt credentials
         postgresPassword = create_password()
@@ -109,7 +111,7 @@ def configure_netmaker(k8s_obj: K8s,
                                   'netmaker',
                                   {'CLIENT_ID': auth_dict['client_id'],
                                    'CLIENT_SECRET': auth_dict['client_secret'],
-                                   'ISSUER': auth_dict['auth_url']}
+                                   'OIDC_SSUER': auth_dict['auth_url']}
                                    )
 
             # create mqtt k8s secret


### PR DESCRIPTION
Fixes #190 and should work with recently merged https://github.com/small-hack/netmaker-helm/pull/7 as well as latest changes to this directory: https://github.com/small-hack/argocd-apps/tree/main/demo/netmaker

## Changes

- Fixed k8s secret generation for netmaker.
- fixed the created zitadel app for netmaker to have the correct logout url/redirect uri
- added a link to the final link block after smol-k8s-lab is done running
- added an experimental doc for netmaker

## NEW netmaker config

The secret keys for netmaker default `init.enabled: true` install are as follows. We have changed the word `endpoint_url` to `hostname` to be consistent. We have also added `broker_hostname` as a configurable value.

```yaml
  netmaker:
    enabled: false
    description: |
      [link=https://www.netmaker.io/]Netmaker[/link]®️  makes networks with WireGuard. Netmaker automates fast, secure, and distributed virtual networks.
    init:
      enabled: true
      values:
        user: admin
    argo:
      # secrets keys to make available to Argo CD ApplicationSets
      secret_keys:
        hostname: netmaker.example.com
        admin_hostname: admin.netmaker.example.com
        api_hostname: api.netmaker.example.com
        broker_hostname: broker.netmaker.example.com
        auth_provider: oidc
```