### PR TITLE
Allow users to not load the pygame mixer if they have text to speech turned off

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1531 562.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1299 562.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,131 +19,131 @@
         font-weight: 700;
     }
 
-    .terminal-1950535455-matrix {
+    .terminal-3887225916-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1950535455-title {
+    .terminal-3887225916-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1950535455-r1 { fill: #c5c8c6 }
-.terminal-1950535455-r2 { fill: #5f87ff }
-.terminal-1950535455-r3 { fill: #5f87af;font-style: italic; }
-.terminal-1950535455-r4 { fill: #5f87af }
-.terminal-1950535455-r5 { fill: #8787ff }
-.terminal-1950535455-r6 { fill: #afafff }
-.terminal-1950535455-r7 { fill: #87afff }
-.terminal-1950535455-r8 { fill: #afafff;font-weight: bold }
-.terminal-1950535455-r9 { fill: #868887 }
-.terminal-1950535455-r10 { fill: #6179a9 }
-.terminal-1950535455-r11 { fill: #6161a9 }
-.terminal-1950535455-r12 { fill: #7979a9;font-weight: bold }
-.terminal-1950535455-r13 { fill: #4961a9 }
+    .terminal-3887225916-r1 { fill: #c5c8c6 }
+.terminal-3887225916-r2 { fill: #5f87ff }
+.terminal-3887225916-r3 { fill: #5f87af;font-style: italic; }
+.terminal-3887225916-r4 { fill: #5f87af }
+.terminal-3887225916-r5 { fill: #8787ff }
+.terminal-3887225916-r6 { fill: #afafff }
+.terminal-3887225916-r7 { fill: #87afff }
+.terminal-3887225916-r8 { fill: #afafff;font-weight: bold }
+.terminal-3887225916-r9 { fill: #868887 }
+.terminal-3887225916-r10 { fill: #6179a9 }
+.terminal-3887225916-r11 { fill: #6161a9 }
+.terminal-3887225916-r12 { fill: #7979a9;font-weight: bold }
+.terminal-3887225916-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-1950535455-clip-terminal">
-      <rect x="0" y="0" width="1511.8" height="511.4" />
+    <clipPath id="terminal-3887225916-clip-terminal">
+      <rect x="0" y="0" width="1280.0" height="511.4" />
     </clipPath>
-    <clipPath id="terminal-1950535455-line-0">
-    <rect x="0" y="1.5" width="1512.8" height="24.65"/>
+    <clipPath id="terminal-3887225916-line-0">
+    <rect x="0" y="1.5" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-1">
-    <rect x="0" y="25.9" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-1">
+    <rect x="0" y="25.9" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-2">
-    <rect x="0" y="50.3" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-2">
+    <rect x="0" y="50.3" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-3">
-    <rect x="0" y="74.7" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-3">
+    <rect x="0" y="74.7" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-4">
-    <rect x="0" y="99.1" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-4">
+    <rect x="0" y="99.1" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-5">
-    <rect x="0" y="123.5" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-5">
+    <rect x="0" y="123.5" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-6">
-    <rect x="0" y="147.9" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-6">
+    <rect x="0" y="147.9" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-7">
-    <rect x="0" y="172.3" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-7">
+    <rect x="0" y="172.3" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-8">
-    <rect x="0" y="196.7" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-8">
+    <rect x="0" y="196.7" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-9">
-    <rect x="0" y="221.1" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-9">
+    <rect x="0" y="221.1" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-10">
-    <rect x="0" y="245.5" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-10">
+    <rect x="0" y="245.5" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-11">
-    <rect x="0" y="269.9" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-11">
+    <rect x="0" y="269.9" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-12">
-    <rect x="0" y="294.3" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-12">
+    <rect x="0" y="294.3" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-13">
-    <rect x="0" y="318.7" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-13">
+    <rect x="0" y="318.7" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-14">
-    <rect x="0" y="343.1" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-14">
+    <rect x="0" y="343.1" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-15">
-    <rect x="0" y="367.5" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-15">
+    <rect x="0" y="367.5" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-16">
-    <rect x="0" y="391.9" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-16">
+    <rect x="0" y="391.9" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-17">
-    <rect x="0" y="416.3" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-17">
+    <rect x="0" y="416.3" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-18">
-    <rect x="0" y="440.7" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-18">
+    <rect x="0" y="440.7" width="1281" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1950535455-line-19">
-    <rect x="0" y="465.1" width="1512.8" height="24.65"/>
+<clipPath id="terminal-3887225916-line-19">
+    <rect x="0" y="465.1" width="1281" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1529" height="560.4" rx="8"/><text class="terminal-1950535455-title" fill="#c5c8c6" text-anchor="middle" x="764" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1297" height="560.4" rx="8"/><text class="terminal-3887225916-title" fill="#c5c8c6" text-anchor="middle" x="648" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1950535455-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3887225916-clip-terminal)">
     
-    <g class="terminal-1950535455-matrix">
-    <text class="terminal-1950535455-r1" x="353.8" y="20" textLength="329.4" clip-path="url(#terminal-1950535455-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-1950535455-r2" x="695.4" y="20" textLength="146.4" clip-path="url(#terminal-1950535455-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-1950535455-r1" x="1512.8" y="20" textLength="12.2" clip-path="url(#terminal-1950535455-line-0)">
-</text><text class="terminal-1950535455-r1" x="1512.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-1)">
-</text><text class="terminal-1950535455-r3" x="353.8" y="68.8" textLength="793" clip-path="url(#terminal-1950535455-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-1950535455-r1" x="1512.8" y="68.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-2)">
-</text><text class="terminal-1950535455-r1" x="1512.8" y="93.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-3)">
-</text><text class="terminal-1950535455-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-1950535455-line-4)">Usage:</text><text class="terminal-1950535455-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-1950535455-line-4)">smol</text><text class="terminal-1950535455-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-4)">-k</text><text class="terminal-1950535455-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-4)">8s</text><text class="terminal-1950535455-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-4)">-l</text><text class="terminal-1950535455-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-4)">ab</text><text class="terminal-1950535455-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1950535455-line-4)">[OPTIONS]</text><text class="terminal-1950535455-r1" x="1512.8" y="117.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-4)">
-</text><text class="terminal-1950535455-r1" x="1512.8" y="142" textLength="12.2" clip-path="url(#terminal-1950535455-line-5)">
-</text><text class="terminal-1950535455-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1950535455-line-6)">╭─</text><text class="terminal-1950535455-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-1950535455-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-1950535455-r6" x="219.6" y="166.4" textLength="1268.8" clip-path="url(#terminal-1950535455-line-6)">────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1950535455-r6" x="1488.4" y="166.4" textLength="24.4" clip-path="url(#terminal-1950535455-line-6)">─╮</text><text class="terminal-1950535455-r1" x="1512.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-6)">
-</text><text class="terminal-1950535455-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-7)">│</text><text class="terminal-1950535455-r6" x="1500.6" y="190.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-7)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-7)">
-</text><text class="terminal-1950535455-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-8)">│</text><text class="terminal-1950535455-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-1950535455-line-8)">-c</text><text class="terminal-1950535455-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-8)">-</text><text class="terminal-1950535455-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-1950535455-line-8)">-c</text><text class="terminal-1950535455-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-1950535455-line-8)">onfig</text><text class="terminal-1950535455-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-1950535455-line-8)">&#160;CONFIG_FILE</text><text class="terminal-1950535455-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-1950535455-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1950535455-r6" x="1500.6" y="215.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-8)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-8)">
-</text><text class="terminal-1950535455-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-9)">│</text><text class="terminal-1950535455-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-1950535455-line-9)">Defaults&#160;to&#160;</text><text class="terminal-1950535455-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-1950535455-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-1950535455-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-1950535455-line-9)">smol</text><text class="terminal-1950535455-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-9)">-k</text><text class="terminal-1950535455-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-9)">8s</text><text class="terminal-1950535455-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-9)">-l</text><text class="terminal-1950535455-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-9)">ab</text><text class="terminal-1950535455-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-1950535455-line-9)">/config.yaml</text><text class="terminal-1950535455-r6" x="1500.6" y="239.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-9)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-9)">
-</text><text class="terminal-1950535455-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1950535455-line-10)">│</text><text class="terminal-1950535455-r6" x="1500.6" y="264" textLength="12.2" clip-path="url(#terminal-1950535455-line-10)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="264" textLength="12.2" clip-path="url(#terminal-1950535455-line-10)">
-</text><text class="terminal-1950535455-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-11)">│</text><text class="terminal-1950535455-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-1950535455-line-11)">-D</text><text class="terminal-1950535455-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-11)">-</text><text class="terminal-1950535455-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-1950535455-line-11)">-d</text><text class="terminal-1950535455-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-1950535455-line-11)">elete</text><text class="terminal-1950535455-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-1950535455-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-1950535455-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-1950535455-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1950535455-r6" x="1500.6" y="288.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-11)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-11)">
-</text><text class="terminal-1950535455-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-12)">│</text><text class="terminal-1950535455-r6" x="1500.6" y="312.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-12)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-12)">
-</text><text class="terminal-1950535455-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-13)">│</text><text class="terminal-1950535455-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1950535455-line-13)">-i</text><text class="terminal-1950535455-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-13)">-</text><text class="terminal-1950535455-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1950535455-line-13)">-i</text><text class="terminal-1950535455-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-1950535455-line-13)">nteractive</text><text class="terminal-1950535455-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-1950535455-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-1950535455-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-1950535455-line-13)">smol</text><text class="terminal-1950535455-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1950535455-line-13)">-k</text><text class="terminal-1950535455-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-1950535455-line-13)">8s</text><text class="terminal-1950535455-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1950535455-line-13)">-l</text><text class="terminal-1950535455-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-1950535455-line-13)">ab</text><text class="terminal-1950535455-r6" x="1500.6" y="337.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-13)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-13)">
-</text><text class="terminal-1950535455-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-14)">│</text><text class="terminal-1950535455-r6" x="1500.6" y="361.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-14)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-14)">
-</text><text class="terminal-1950535455-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1950535455-line-15)">│</text><text class="terminal-1950535455-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1950535455-line-15)">-v</text><text class="terminal-1950535455-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-1950535455-line-15)">-</text><text class="terminal-1950535455-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-1950535455-line-15)">-v</text><text class="terminal-1950535455-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-1950535455-line-15)">ersion</text><text class="terminal-1950535455-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-1950535455-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-1950535455-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-1950535455-line-15)">smol</text><text class="terminal-1950535455-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-1950535455-line-15)">-k</text><text class="terminal-1950535455-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-1950535455-line-15)">8s</text><text class="terminal-1950535455-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-1950535455-line-15)">-l</text><text class="terminal-1950535455-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-1950535455-line-15)">ab</text><text class="terminal-1950535455-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-1950535455-line-15)">&#160;(v5.0.3)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1950535455-r6" x="1500.6" y="386" textLength="12.2" clip-path="url(#terminal-1950535455-line-15)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="386" textLength="12.2" clip-path="url(#terminal-1950535455-line-15)">
-</text><text class="terminal-1950535455-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-16)">│</text><text class="terminal-1950535455-r6" x="1500.6" y="410.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-16)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1950535455-line-16)">
-</text><text class="terminal-1950535455-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-17)">│</text><text class="terminal-1950535455-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1950535455-line-17)">-f</text><text class="terminal-1950535455-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-17)">-</text><text class="terminal-1950535455-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1950535455-line-17)">-f</text><text class="terminal-1950535455-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-1950535455-line-17)">inal_cmd</text><text class="terminal-1950535455-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-1950535455-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-1950535455-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-1950535455-line-17)">smol</text><text class="terminal-1950535455-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1950535455-line-17)">-k</text><text class="terminal-1950535455-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-1950535455-line-17)">8s</text><text class="terminal-1950535455-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-1950535455-line-17)">-l</text><text class="terminal-1950535455-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1950535455-line-17)">ab</text><text class="terminal-1950535455-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-1950535455-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-1950535455-r6" x="1500.6" y="434.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-17)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="434.8" textLength="12.2" clip-path="url(#terminal-1950535455-line-17)">
-</text><text class="terminal-1950535455-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-18)">│</text><text class="terminal-1950535455-r6" x="1500.6" y="459.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-18)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="459.2" textLength="12.2" clip-path="url(#terminal-1950535455-line-18)">
-</text><text class="terminal-1950535455-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-19)">│</text><text class="terminal-1950535455-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-19)">-h</text><text class="terminal-1950535455-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-19)">-</text><text class="terminal-1950535455-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-1950535455-line-19)">-h</text><text class="terminal-1950535455-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-1950535455-line-19)">elp</text><text class="terminal-1950535455-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-1950535455-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1950535455-r6" x="1500.6" y="483.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-19)">│</text><text class="terminal-1950535455-r1" x="1512.8" y="483.6" textLength="12.2" clip-path="url(#terminal-1950535455-line-19)">
-</text><text class="terminal-1950535455-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-1950535455-line-20)">╰─</text><text class="terminal-1950535455-r6" x="24.4" y="508" textLength="841.8" clip-path="url(#terminal-1950535455-line-20)">─────────────────────────────────────────────────────────────────────</text><text class="terminal-1950535455-r6" x="866.2" y="508" textLength="109.8" clip-path="url(#terminal-1950535455-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-1950535455-r6" x="976" y="508" textLength="500.2" clip-path="url(#terminal-1950535455-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-1950535455-r6" x="1488.4" y="508" textLength="24.4" clip-path="url(#terminal-1950535455-line-20)">─╯</text><text class="terminal-1950535455-r1" x="1512.8" y="508" textLength="12.2" clip-path="url(#terminal-1950535455-line-20)">
+    <g class="terminal-3887225916-matrix">
+    <text class="terminal-3887225916-r1" x="244" y="20" textLength="329.4" clip-path="url(#terminal-3887225916-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-3887225916-r2" x="585.6" y="20" textLength="146.4" clip-path="url(#terminal-3887225916-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-3887225916-r1" x="1281" y="20" textLength="12.2" clip-path="url(#terminal-3887225916-line-0)">
+</text><text class="terminal-3887225916-r1" x="1281" y="44.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-1)">
+</text><text class="terminal-3887225916-r3" x="244" y="68.8" textLength="793" clip-path="url(#terminal-3887225916-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-3887225916-r1" x="1281" y="68.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-2)">
+</text><text class="terminal-3887225916-r1" x="1281" y="93.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-3)">
+</text><text class="terminal-3887225916-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-3887225916-line-4)">Usage:</text><text class="terminal-3887225916-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-3887225916-line-4)">smol</text><text class="terminal-3887225916-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-4)">-k</text><text class="terminal-3887225916-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-4)">8s</text><text class="terminal-3887225916-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-4)">-l</text><text class="terminal-3887225916-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-4)">ab</text><text class="terminal-3887225916-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-3887225916-line-4)">[OPTIONS]</text><text class="terminal-3887225916-r1" x="1281" y="117.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-4)">
+</text><text class="terminal-3887225916-r1" x="1281" y="142" textLength="12.2" clip-path="url(#terminal-3887225916-line-5)">
+</text><text class="terminal-3887225916-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-3887225916-line-6)">╭─</text><text class="terminal-3887225916-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-3887225916-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-3887225916-r6" x="219.6" y="166.4" textLength="1037" clip-path="url(#terminal-3887225916-line-6)">─────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-3887225916-r6" x="1256.6" y="166.4" textLength="24.4" clip-path="url(#terminal-3887225916-line-6)">─╮</text><text class="terminal-3887225916-r1" x="1281" y="166.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-6)">
+</text><text class="terminal-3887225916-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-7)">│</text><text class="terminal-3887225916-r6" x="1268.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-7)">│</text><text class="terminal-3887225916-r1" x="1281" y="190.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-7)">
+</text><text class="terminal-3887225916-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-8)">│</text><text class="terminal-3887225916-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-3887225916-line-8)">-c</text><text class="terminal-3887225916-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-8)">-</text><text class="terminal-3887225916-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-3887225916-line-8)">-c</text><text class="terminal-3887225916-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-3887225916-line-8)">onfig</text><text class="terminal-3887225916-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-3887225916-line-8)">&#160;CONFIG_FILE</text><text class="terminal-3887225916-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-3887225916-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3887225916-r6" x="1268.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-8)">│</text><text class="terminal-3887225916-r1" x="1281" y="215.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-8)">
+</text><text class="terminal-3887225916-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-9)">│</text><text class="terminal-3887225916-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-3887225916-line-9)">Defaults&#160;to&#160;</text><text class="terminal-3887225916-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-3887225916-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-3887225916-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-3887225916-line-9)">smol</text><text class="terminal-3887225916-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-9)">-k</text><text class="terminal-3887225916-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-9)">8s</text><text class="terminal-3887225916-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-9)">-l</text><text class="terminal-3887225916-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-9)">ab</text><text class="terminal-3887225916-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-3887225916-line-9)">/config.yaml</text><text class="terminal-3887225916-r6" x="1268.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-9)">│</text><text class="terminal-3887225916-r1" x="1281" y="239.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-9)">
+</text><text class="terminal-3887225916-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3887225916-line-10)">│</text><text class="terminal-3887225916-r6" x="1268.8" y="264" textLength="12.2" clip-path="url(#terminal-3887225916-line-10)">│</text><text class="terminal-3887225916-r1" x="1281" y="264" textLength="12.2" clip-path="url(#terminal-3887225916-line-10)">
+</text><text class="terminal-3887225916-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-11)">│</text><text class="terminal-3887225916-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-3887225916-line-11)">-D</text><text class="terminal-3887225916-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-11)">-</text><text class="terminal-3887225916-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-3887225916-line-11)">-d</text><text class="terminal-3887225916-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-3887225916-line-11)">elete</text><text class="terminal-3887225916-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-3887225916-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-3887225916-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-3887225916-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3887225916-r6" x="1268.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-11)">│</text><text class="terminal-3887225916-r1" x="1281" y="288.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-11)">
+</text><text class="terminal-3887225916-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-12)">│</text><text class="terminal-3887225916-r6" x="1268.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-12)">│</text><text class="terminal-3887225916-r1" x="1281" y="312.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-12)">
+</text><text class="terminal-3887225916-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-13)">│</text><text class="terminal-3887225916-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-3887225916-line-13)">-i</text><text class="terminal-3887225916-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-13)">-</text><text class="terminal-3887225916-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-3887225916-line-13)">-i</text><text class="terminal-3887225916-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-3887225916-line-13)">nteractive</text><text class="terminal-3887225916-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-3887225916-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-3887225916-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-3887225916-line-13)">smol</text><text class="terminal-3887225916-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-3887225916-line-13)">-k</text><text class="terminal-3887225916-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-3887225916-line-13)">8s</text><text class="terminal-3887225916-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-3887225916-line-13)">-l</text><text class="terminal-3887225916-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-3887225916-line-13)">ab</text><text class="terminal-3887225916-r6" x="1268.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-13)">│</text><text class="terminal-3887225916-r1" x="1281" y="337.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-13)">
+</text><text class="terminal-3887225916-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-14)">│</text><text class="terminal-3887225916-r6" x="1268.8" y="361.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-14)">│</text><text class="terminal-3887225916-r1" x="1281" y="361.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-14)">
+</text><text class="terminal-3887225916-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-3887225916-line-15)">│</text><text class="terminal-3887225916-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-3887225916-line-15)">-v</text><text class="terminal-3887225916-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-3887225916-line-15)">-</text><text class="terminal-3887225916-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-3887225916-line-15)">-v</text><text class="terminal-3887225916-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-3887225916-line-15)">ersion</text><text class="terminal-3887225916-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-3887225916-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-3887225916-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-3887225916-line-15)">smol</text><text class="terminal-3887225916-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-3887225916-line-15)">-k</text><text class="terminal-3887225916-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-3887225916-line-15)">8s</text><text class="terminal-3887225916-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-3887225916-line-15)">-l</text><text class="terminal-3887225916-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-3887225916-line-15)">ab</text><text class="terminal-3887225916-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-3887225916-line-15)">&#160;(v5.0.4)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3887225916-r6" x="1268.8" y="386" textLength="12.2" clip-path="url(#terminal-3887225916-line-15)">│</text><text class="terminal-3887225916-r1" x="1281" y="386" textLength="12.2" clip-path="url(#terminal-3887225916-line-15)">
+</text><text class="terminal-3887225916-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-16)">│</text><text class="terminal-3887225916-r6" x="1268.8" y="410.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-16)">│</text><text class="terminal-3887225916-r1" x="1281" y="410.4" textLength="12.2" clip-path="url(#terminal-3887225916-line-16)">
+</text><text class="terminal-3887225916-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-17)">│</text><text class="terminal-3887225916-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-3887225916-line-17)">-f</text><text class="terminal-3887225916-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-17)">-</text><text class="terminal-3887225916-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-3887225916-line-17)">-f</text><text class="terminal-3887225916-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-3887225916-line-17)">inal_cmd</text><text class="terminal-3887225916-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-3887225916-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-3887225916-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-3887225916-line-17)">smol</text><text class="terminal-3887225916-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-3887225916-line-17)">-k</text><text class="terminal-3887225916-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-3887225916-line-17)">8s</text><text class="terminal-3887225916-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-3887225916-line-17)">-l</text><text class="terminal-3887225916-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-3887225916-line-17)">ab</text><text class="terminal-3887225916-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-3887225916-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-3887225916-r6" x="1268.8" y="434.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-17)">│</text><text class="terminal-3887225916-r1" x="1281" y="434.8" textLength="12.2" clip-path="url(#terminal-3887225916-line-17)">
+</text><text class="terminal-3887225916-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-18)">│</text><text class="terminal-3887225916-r6" x="1268.8" y="459.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-18)">│</text><text class="terminal-3887225916-r1" x="1281" y="459.2" textLength="12.2" clip-path="url(#terminal-3887225916-line-18)">
+</text><text class="terminal-3887225916-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-19)">│</text><text class="terminal-3887225916-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-19)">-h</text><text class="terminal-3887225916-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-19)">-</text><text class="terminal-3887225916-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-3887225916-line-19)">-h</text><text class="terminal-3887225916-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-3887225916-line-19)">elp</text><text class="terminal-3887225916-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-3887225916-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3887225916-r6" x="1268.8" y="483.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-19)">│</text><text class="terminal-3887225916-r1" x="1281" y="483.6" textLength="12.2" clip-path="url(#terminal-3887225916-line-19)">
+</text><text class="terminal-3887225916-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-3887225916-line-20)">╰─</text><text class="terminal-3887225916-r6" x="24.4" y="508" textLength="610" clip-path="url(#terminal-3887225916-line-20)">──────────────────────────────────────────────────</text><text class="terminal-3887225916-r6" x="634.4" y="508" textLength="109.8" clip-path="url(#terminal-3887225916-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-3887225916-r6" x="744.2" y="508" textLength="500.2" clip-path="url(#terminal-3887225916-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-3887225916-r6" x="1256.6" y="508" textLength="24.4" clip-path="url(#terminal-3887225916-line-20)">─╯</text><text class="terminal-3887225916-r1" x="1281" y="508" textLength="12.2" clip-path="url(#terminal-3887225916-line-20)">
 </text>
     </g>
     </g>

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -14,6 +14,7 @@ You can checkout the full official current [default `config.yaml`](https://githu
 
 You can checkout more about the TUI in [our tui config section](/tui), but briefly please see the default configuration for in the yaml below:
 
+### Visual TUI config options
 ```yaml
 smol_k8s_lab:
   # Terminal User Interface with clickable buttons.
@@ -24,14 +25,27 @@ smol_k8s_lab:
     enabled: true
     # show bottom footer help bar
     show_footer: true
+```
+
+### Accessibility Options
+
+???+ tip
+    If you are using smol-k8s-lab via SSH or on a machine that does not have audio drivers installed, you may experience errors in the TUI related to Alsa not running. You can disable ALL of the text to speech and terminal bell features to make it go away.
+
+Below are all the currently supported accessibility features in the `smol-k8s-lab` TUI. If you have experience with python and screenreaders or working in the terminal using screen readers generally, please reach out on GitHub via an Issue or Discussion. We'd love your opinions and help on making our interface more accessible. We're also happy to hear more feed back on other accessibility features!
+
+
+#### Text to Speech
+
+These are all the options related to text to speech:
+
+```yaml
+smol_k8s_lab:
+  # Terminal User Interface with clickable buttons.
+  # Useful for learning smol-k8s-lab or verifying your configuration
+  tui:
     # accessibility options for users that benefit from TTS and Bell sounds
     accessibility:
-      # options related to terminal bell sounds
-      bell:
-        # ring the built in terminal bell on focus to new elements on the screen
-        on_focus: true
-        # ring the built in terminal bell when something is wrong
-        on_error: true
       # options related to text to speech
       text_to_speech:
         # language to speak in. so far only english supported
@@ -48,7 +62,24 @@ smol_k8s_lab:
         on_key_press: true
 ```
 
-Regarding the `smol_k8s_lab.tui.accessibility` section. If you have experience with programming python on linux to work with screenreaders or working in the terminal using screen readers generally, please reach out on GitHub via an Issue or Discussion. We'd love your opinions and help!
+#### Terminal Bell
+
+These options use your built in terminal bell:
+
+```yaml
+smol_k8s_lab:
+  # Terminal User Interface with clickable buttons.
+  # Useful for learning smol-k8s-lab or verifying your configuration
+  tui:
+    # accessibility options for users that benefit from TTS and Bell sounds
+    accessibility:
+      # options related to terminal bell sounds
+      bell:
+        # ring the built in terminal bell on focus to new elements on the screen
+        on_focus: true
+        # ring the built in terminal bell when something is wrong
+        on_error: true
+```
 
 ## Run command
 

--- a/docs/tui/tui_config.md
+++ b/docs/tui/tui_config.md
@@ -1,14 +1,14 @@
 ## TUI and Accessibility configuration
 
-You can configure the TUI (Terminal User Interface) either via the config file, or via the TUI itself.
+You can configure the TUI (Terminal User Interface), including accessibility features, either via the config file, or via the TUI itself.
 
-From any screen in the TUI, you can press ++c++ and it will bring up the TUI config.
+From any screen in the TUI, you can press ++c++ and it will bring up the Accessibility and TUI config screen.
 
 ![terminal screenshot showing the smol-k8s-lab configure accessibility options and tui config screen. There are two boxes. Box one: Configure accessibility features. The first header in the box says Terminal Bell config and features a section with two switches: bell on focus, and bell on error. The second header in the first box says Text to speech Config. Below are three rows. The first row has a input field for speech program with placeholder text that says name of program for speech. The 2nd row has two switches. Switch one is on key press, and the switch two is on focus. The final row in the 1st box has two switches. Switch one is screen titles, and switch two is screen descriptions. The second box on this screen is titled configure terminal UI and it features two switches. Box two's first switch is TUI enabled, and the second switch is footer enabaled.](../../assets/images/screenshots/tui_config_screen.svg)
 
-Some options may not take effect till you return to the start screen or restart the program.
+Some options may not take effect until you return to the start screen or restart the program.
 
-To exit the TUI config, just press ++q++ or ++esc++.
+To exit the TUI config screen, just press ++q++ or ++esc++.
 
 To checkout more information on configuring accessibility options via the config file, check out our examples [here](/config_file/#tui-and-accessibility-configuration).
 
@@ -44,6 +44,10 @@ There's a special screen that pops up just before the [confirmation screen](/tui
 ![terminal screenshot showing the smol-k8s-lab configure logging, password management, and run command config screen. The screen features three main boxes. Box one title is configure logging. It says configure logging for all of smol-k8s-lab. Below the text it has a level dropdown set to debug and a file input with no value. The seond box title is configure password manager. The text reads Save app credentials to a local password manager vault. Only Bitwarden is supported at this time, but if enabled, Bitwarden can be used as your k8s external secret provider. To avoid a password prompt, export the following env vars: BW_PASSWORD, BW_CLIENTID, BW_CLIENTSECRET. Below that is a row with an enabled switch and a duplicate strategy drop down menu set to edit. The final box on the screen is titled configure command to run after config. The text reads If window behavior is set to same window, command runs after smol-k8s-lab has completed. The first row in the box features a teminal dropdown set wezterm, and a window behavior drop down menu set to split right. The final row in the box is a command input field and it is set to k9s --command applications.argoproj.io](../../assets/images/screenshots/logging_password_config.svg)
 
 ## FAQ
+
+### I'm getting Alsa errors whenever I launch the TUI over SSH or on a machine without audio drivers.
+
+This is because we use your terminal bell or we're trying to use text to speech. You can disable text to speech and bell by hitting ++C++ anywhere in the TUI and then switching all the switches under Accessibility to the off position. Alternatively, you can disable all of this in the `$XDG_CONFIG_HOME/smol-k8s-lab/config.yaml` (If you don't have the `$XDG_CONFIG_HOME` env var configured, we will default to `~/.config/smol-k8s-lab/config.yaml`). See the [TUI and Accessibility config file docs](/config_file/#tui-and-accessibility-configuration) for more info on how to do this via the config file.
 
 ### Why does the `smol-k8s-lab` look weird in the default macOS terminal?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "5.0.3"
+version       = "5.0.4"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]


### PR DESCRIPTION
This only loads the pygame mixer if a user has text to speech options enabled in the config file, otherwise, they can get errors in the TUI.

Also add some docs explaining that you need to turn off all text to speech options to avoid alsa errors if running on a machine without sound capabilities or via SSH. You may still get Alsa errors if you have `bell_on_error` or `bell_on_focus` on, because they may also use Alsa, so you may have to turn those off too. Also tidied the accessibility features tui docs.