### PR TITLE
Fix matrix stable installs to ignore if sliding sync or MAS not enabled for bitwarden IDs; update kubernetes and textual

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1360 562.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1190 562.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,131 +19,131 @@
         font-weight: 700;
     }
 
-    .terminal-1883077242-matrix {
+    .terminal-4154074577-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1883077242-title {
+    .terminal-4154074577-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1883077242-r1 { fill: #c5c8c6 }
-.terminal-1883077242-r2 { fill: #5f87ff }
-.terminal-1883077242-r3 { fill: #5f87af;font-style: italic; }
-.terminal-1883077242-r4 { fill: #5f87af }
-.terminal-1883077242-r5 { fill: #8787ff }
-.terminal-1883077242-r6 { fill: #afafff }
-.terminal-1883077242-r7 { fill: #87afff }
-.terminal-1883077242-r8 { fill: #afafff;font-weight: bold }
-.terminal-1883077242-r9 { fill: #868887 }
-.terminal-1883077242-r10 { fill: #6179a9 }
-.terminal-1883077242-r11 { fill: #6161a9 }
-.terminal-1883077242-r12 { fill: #7979a9;font-weight: bold }
-.terminal-1883077242-r13 { fill: #4961a9 }
+    .terminal-4154074577-r1 { fill: #c5c8c6 }
+.terminal-4154074577-r2 { fill: #5f87ff }
+.terminal-4154074577-r3 { fill: #5f87af;font-style: italic; }
+.terminal-4154074577-r4 { fill: #5f87af }
+.terminal-4154074577-r5 { fill: #8787ff }
+.terminal-4154074577-r6 { fill: #afafff }
+.terminal-4154074577-r7 { fill: #87afff }
+.terminal-4154074577-r8 { fill: #afafff;font-weight: bold }
+.terminal-4154074577-r9 { fill: #868887 }
+.terminal-4154074577-r10 { fill: #6179a9 }
+.terminal-4154074577-r11 { fill: #6161a9 }
+.terminal-4154074577-r12 { fill: #7979a9;font-weight: bold }
+.terminal-4154074577-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-1883077242-clip-terminal">
-      <rect x="0" y="0" width="1341.0" height="511.4" />
+    <clipPath id="terminal-4154074577-clip-terminal">
+      <rect x="0" y="0" width="1170.1999999999998" height="511.4" />
     </clipPath>
-    <clipPath id="terminal-1883077242-line-0">
-    <rect x="0" y="1.5" width="1342" height="24.65"/>
+    <clipPath id="terminal-4154074577-line-0">
+    <rect x="0" y="1.5" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-1">
-    <rect x="0" y="25.9" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-1">
+    <rect x="0" y="25.9" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-2">
-    <rect x="0" y="50.3" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-2">
+    <rect x="0" y="50.3" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-3">
-    <rect x="0" y="74.7" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-3">
+    <rect x="0" y="74.7" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-4">
-    <rect x="0" y="99.1" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-4">
+    <rect x="0" y="99.1" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-5">
-    <rect x="0" y="123.5" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-5">
+    <rect x="0" y="123.5" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-6">
-    <rect x="0" y="147.9" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-6">
+    <rect x="0" y="147.9" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-7">
-    <rect x="0" y="172.3" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-7">
+    <rect x="0" y="172.3" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-8">
-    <rect x="0" y="196.7" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-8">
+    <rect x="0" y="196.7" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-9">
-    <rect x="0" y="221.1" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-9">
+    <rect x="0" y="221.1" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-10">
-    <rect x="0" y="245.5" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-10">
+    <rect x="0" y="245.5" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-11">
-    <rect x="0" y="269.9" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-11">
+    <rect x="0" y="269.9" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-12">
-    <rect x="0" y="294.3" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-12">
+    <rect x="0" y="294.3" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-13">
-    <rect x="0" y="318.7" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-13">
+    <rect x="0" y="318.7" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-14">
-    <rect x="0" y="343.1" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-14">
+    <rect x="0" y="343.1" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-15">
-    <rect x="0" y="367.5" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-15">
+    <rect x="0" y="367.5" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-16">
-    <rect x="0" y="391.9" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-16">
+    <rect x="0" y="391.9" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-17">
-    <rect x="0" y="416.3" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-17">
+    <rect x="0" y="416.3" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-18">
-    <rect x="0" y="440.7" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-18">
+    <rect x="0" y="440.7" width="1171.2" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1883077242-line-19">
-    <rect x="0" y="465.1" width="1342" height="24.65"/>
+<clipPath id="terminal-4154074577-line-19">
+    <rect x="0" y="465.1" width="1171.2" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1358" height="560.4" rx="8"/><text class="terminal-1883077242-title" fill="#c5c8c6" text-anchor="middle" x="679" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1188" height="560.4" rx="8"/><text class="terminal-4154074577-title" fill="#c5c8c6" text-anchor="middle" x="594" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1883077242-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4154074577-clip-terminal)">
     
-    <g class="terminal-1883077242-matrix">
-    <text class="terminal-1883077242-r1" x="268.4" y="20" textLength="329.4" clip-path="url(#terminal-1883077242-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-1883077242-r2" x="610" y="20" textLength="146.4" clip-path="url(#terminal-1883077242-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-1883077242-r1" x="1342" y="20" textLength="12.2" clip-path="url(#terminal-1883077242-line-0)">
-</text><text class="terminal-1883077242-r1" x="1342" y="44.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-1)">
-</text><text class="terminal-1883077242-r3" x="268.4" y="68.8" textLength="793" clip-path="url(#terminal-1883077242-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-1883077242-r1" x="1342" y="68.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-2)">
-</text><text class="terminal-1883077242-r1" x="1342" y="93.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-3)">
-</text><text class="terminal-1883077242-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-1883077242-line-4)">Usage:</text><text class="terminal-1883077242-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-1883077242-line-4)">smol</text><text class="terminal-1883077242-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-4)">-k</text><text class="terminal-1883077242-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-4)">8s</text><text class="terminal-1883077242-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-4)">-l</text><text class="terminal-1883077242-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-4)">ab</text><text class="terminal-1883077242-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1883077242-line-4)">[OPTIONS]</text><text class="terminal-1883077242-r1" x="1342" y="117.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-4)">
-</text><text class="terminal-1883077242-r1" x="1342" y="142" textLength="12.2" clip-path="url(#terminal-1883077242-line-5)">
-</text><text class="terminal-1883077242-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1883077242-line-6)">╭─</text><text class="terminal-1883077242-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-1883077242-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-1883077242-r6" x="219.6" y="166.4" textLength="1098" clip-path="url(#terminal-1883077242-line-6)">──────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1883077242-r6" x="1317.6" y="166.4" textLength="24.4" clip-path="url(#terminal-1883077242-line-6)">─╮</text><text class="terminal-1883077242-r1" x="1342" y="166.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-6)">
-</text><text class="terminal-1883077242-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-7)">│</text><text class="terminal-1883077242-r6" x="1329.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-7)">│</text><text class="terminal-1883077242-r1" x="1342" y="190.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-7)">
-</text><text class="terminal-1883077242-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-8)">│</text><text class="terminal-1883077242-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-1883077242-line-8)">-c</text><text class="terminal-1883077242-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-8)">-</text><text class="terminal-1883077242-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-1883077242-line-8)">-c</text><text class="terminal-1883077242-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-1883077242-line-8)">onfig</text><text class="terminal-1883077242-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-1883077242-line-8)">&#160;CONFIG_FILE</text><text class="terminal-1883077242-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-1883077242-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1883077242-r6" x="1329.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-8)">│</text><text class="terminal-1883077242-r1" x="1342" y="215.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-8)">
-</text><text class="terminal-1883077242-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-9)">│</text><text class="terminal-1883077242-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-1883077242-line-9)">Defaults&#160;to&#160;</text><text class="terminal-1883077242-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-1883077242-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-1883077242-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-1883077242-line-9)">smol</text><text class="terminal-1883077242-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-9)">-k</text><text class="terminal-1883077242-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-9)">8s</text><text class="terminal-1883077242-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-9)">-l</text><text class="terminal-1883077242-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-9)">ab</text><text class="terminal-1883077242-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-1883077242-line-9)">/config.yaml</text><text class="terminal-1883077242-r6" x="1329.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-9)">│</text><text class="terminal-1883077242-r1" x="1342" y="239.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-9)">
-</text><text class="terminal-1883077242-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1883077242-line-10)">│</text><text class="terminal-1883077242-r6" x="1329.8" y="264" textLength="12.2" clip-path="url(#terminal-1883077242-line-10)">│</text><text class="terminal-1883077242-r1" x="1342" y="264" textLength="12.2" clip-path="url(#terminal-1883077242-line-10)">
-</text><text class="terminal-1883077242-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-11)">│</text><text class="terminal-1883077242-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-1883077242-line-11)">-D</text><text class="terminal-1883077242-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-11)">-</text><text class="terminal-1883077242-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-1883077242-line-11)">-d</text><text class="terminal-1883077242-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-1883077242-line-11)">elete</text><text class="terminal-1883077242-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-1883077242-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-1883077242-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-1883077242-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1883077242-r6" x="1329.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-11)">│</text><text class="terminal-1883077242-r1" x="1342" y="288.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-11)">
-</text><text class="terminal-1883077242-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-12)">│</text><text class="terminal-1883077242-r6" x="1329.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-12)">│</text><text class="terminal-1883077242-r1" x="1342" y="312.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-12)">
-</text><text class="terminal-1883077242-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-13)">│</text><text class="terminal-1883077242-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1883077242-line-13)">-i</text><text class="terminal-1883077242-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-13)">-</text><text class="terminal-1883077242-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1883077242-line-13)">-i</text><text class="terminal-1883077242-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-1883077242-line-13)">nteractive</text><text class="terminal-1883077242-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-1883077242-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-1883077242-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-1883077242-line-13)">smol</text><text class="terminal-1883077242-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1883077242-line-13)">-k</text><text class="terminal-1883077242-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-1883077242-line-13)">8s</text><text class="terminal-1883077242-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1883077242-line-13)">-l</text><text class="terminal-1883077242-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-1883077242-line-13)">ab</text><text class="terminal-1883077242-r6" x="1329.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-13)">│</text><text class="terminal-1883077242-r1" x="1342" y="337.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-13)">
-</text><text class="terminal-1883077242-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-14)">│</text><text class="terminal-1883077242-r6" x="1329.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-14)">│</text><text class="terminal-1883077242-r1" x="1342" y="361.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-14)">
-</text><text class="terminal-1883077242-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1883077242-line-15)">│</text><text class="terminal-1883077242-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1883077242-line-15)">-v</text><text class="terminal-1883077242-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-1883077242-line-15)">-</text><text class="terminal-1883077242-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-1883077242-line-15)">-v</text><text class="terminal-1883077242-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-1883077242-line-15)">ersion</text><text class="terminal-1883077242-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-1883077242-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-1883077242-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-1883077242-line-15)">smol</text><text class="terminal-1883077242-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-1883077242-line-15)">-k</text><text class="terminal-1883077242-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-1883077242-line-15)">8s</text><text class="terminal-1883077242-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-1883077242-line-15)">-l</text><text class="terminal-1883077242-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-1883077242-line-15)">ab</text><text class="terminal-1883077242-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-1883077242-line-15)">&#160;(v5.4.2)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1883077242-r6" x="1329.8" y="386" textLength="12.2" clip-path="url(#terminal-1883077242-line-15)">│</text><text class="terminal-1883077242-r1" x="1342" y="386" textLength="12.2" clip-path="url(#terminal-1883077242-line-15)">
-</text><text class="terminal-1883077242-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-16)">│</text><text class="terminal-1883077242-r6" x="1329.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-16)">│</text><text class="terminal-1883077242-r1" x="1342" y="410.4" textLength="12.2" clip-path="url(#terminal-1883077242-line-16)">
-</text><text class="terminal-1883077242-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-17)">│</text><text class="terminal-1883077242-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1883077242-line-17)">-f</text><text class="terminal-1883077242-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-17)">-</text><text class="terminal-1883077242-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1883077242-line-17)">-f</text><text class="terminal-1883077242-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-1883077242-line-17)">inal_cmd</text><text class="terminal-1883077242-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-1883077242-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-1883077242-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-1883077242-line-17)">smol</text><text class="terminal-1883077242-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1883077242-line-17)">-k</text><text class="terminal-1883077242-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-1883077242-line-17)">8s</text><text class="terminal-1883077242-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-1883077242-line-17)">-l</text><text class="terminal-1883077242-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1883077242-line-17)">ab</text><text class="terminal-1883077242-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-1883077242-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-1883077242-r6" x="1329.8" y="434.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-17)">│</text><text class="terminal-1883077242-r1" x="1342" y="434.8" textLength="12.2" clip-path="url(#terminal-1883077242-line-17)">
-</text><text class="terminal-1883077242-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-18)">│</text><text class="terminal-1883077242-r6" x="1329.8" y="459.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-18)">│</text><text class="terminal-1883077242-r1" x="1342" y="459.2" textLength="12.2" clip-path="url(#terminal-1883077242-line-18)">
-</text><text class="terminal-1883077242-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-19)">│</text><text class="terminal-1883077242-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-19)">-h</text><text class="terminal-1883077242-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-19)">-</text><text class="terminal-1883077242-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-1883077242-line-19)">-h</text><text class="terminal-1883077242-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-1883077242-line-19)">elp</text><text class="terminal-1883077242-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-1883077242-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1883077242-r6" x="1329.8" y="483.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-19)">│</text><text class="terminal-1883077242-r1" x="1342" y="483.6" textLength="12.2" clip-path="url(#terminal-1883077242-line-19)">
-</text><text class="terminal-1883077242-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-1883077242-line-20)">╰─</text><text class="terminal-1883077242-r6" x="24.4" y="508" textLength="671" clip-path="url(#terminal-1883077242-line-20)">───────────────────────────────────────────────────────</text><text class="terminal-1883077242-r6" x="695.4" y="508" textLength="109.8" clip-path="url(#terminal-1883077242-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-1883077242-r6" x="805.2" y="508" textLength="500.2" clip-path="url(#terminal-1883077242-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-1883077242-r6" x="1317.6" y="508" textLength="24.4" clip-path="url(#terminal-1883077242-line-20)">─╯</text><text class="terminal-1883077242-r1" x="1342" y="508" textLength="12.2" clip-path="url(#terminal-1883077242-line-20)">
+    <g class="terminal-4154074577-matrix">
+    <text class="terminal-4154074577-r1" x="183" y="20" textLength="329.4" clip-path="url(#terminal-4154074577-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-4154074577-r2" x="524.6" y="20" textLength="146.4" clip-path="url(#terminal-4154074577-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-4154074577-r1" x="1171.2" y="20" textLength="12.2" clip-path="url(#terminal-4154074577-line-0)">
+</text><text class="terminal-4154074577-r1" x="1171.2" y="44.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-1)">
+</text><text class="terminal-4154074577-r3" x="183" y="68.8" textLength="793" clip-path="url(#terminal-4154074577-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-4154074577-r1" x="1171.2" y="68.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-2)">
+</text><text class="terminal-4154074577-r1" x="1171.2" y="93.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-3)">
+</text><text class="terminal-4154074577-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-4154074577-line-4)">Usage:</text><text class="terminal-4154074577-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-4154074577-line-4)">smol</text><text class="terminal-4154074577-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-4)">-k</text><text class="terminal-4154074577-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-4)">8s</text><text class="terminal-4154074577-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-4)">-l</text><text class="terminal-4154074577-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-4)">ab</text><text class="terminal-4154074577-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-4154074577-line-4)">[OPTIONS]</text><text class="terminal-4154074577-r1" x="1171.2" y="117.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-4)">
+</text><text class="terminal-4154074577-r1" x="1171.2" y="142" textLength="12.2" clip-path="url(#terminal-4154074577-line-5)">
+</text><text class="terminal-4154074577-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-4154074577-line-6)">╭─</text><text class="terminal-4154074577-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-4154074577-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-4154074577-r6" x="219.6" y="166.4" textLength="927.2" clip-path="url(#terminal-4154074577-line-6)">────────────────────────────────────────────────────────────────────────────</text><text class="terminal-4154074577-r6" x="1146.8" y="166.4" textLength="24.4" clip-path="url(#terminal-4154074577-line-6)">─╮</text><text class="terminal-4154074577-r1" x="1171.2" y="166.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-6)">
+</text><text class="terminal-4154074577-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-7)">│</text><text class="terminal-4154074577-r6" x="1159" y="190.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-7)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="190.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-7)">
+</text><text class="terminal-4154074577-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-8)">│</text><text class="terminal-4154074577-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-4154074577-line-8)">-c</text><text class="terminal-4154074577-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-8)">-</text><text class="terminal-4154074577-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-4154074577-line-8)">-c</text><text class="terminal-4154074577-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-4154074577-line-8)">onfig</text><text class="terminal-4154074577-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-4154074577-line-8)">&#160;CONFIG_FILE</text><text class="terminal-4154074577-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-4154074577-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4154074577-r6" x="1159" y="215.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-8)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="215.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-8)">
+</text><text class="terminal-4154074577-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-9)">│</text><text class="terminal-4154074577-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-4154074577-line-9)">Defaults&#160;to&#160;</text><text class="terminal-4154074577-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-4154074577-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-4154074577-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-4154074577-line-9)">smol</text><text class="terminal-4154074577-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-9)">-k</text><text class="terminal-4154074577-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-9)">8s</text><text class="terminal-4154074577-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-9)">-l</text><text class="terminal-4154074577-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-9)">ab</text><text class="terminal-4154074577-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-4154074577-line-9)">/config.yaml</text><text class="terminal-4154074577-r6" x="1159" y="239.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-9)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="239.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-9)">
+</text><text class="terminal-4154074577-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-4154074577-line-10)">│</text><text class="terminal-4154074577-r6" x="1159" y="264" textLength="12.2" clip-path="url(#terminal-4154074577-line-10)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="264" textLength="12.2" clip-path="url(#terminal-4154074577-line-10)">
+</text><text class="terminal-4154074577-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-11)">│</text><text class="terminal-4154074577-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-4154074577-line-11)">-D</text><text class="terminal-4154074577-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-11)">-</text><text class="terminal-4154074577-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-4154074577-line-11)">-d</text><text class="terminal-4154074577-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-4154074577-line-11)">elete</text><text class="terminal-4154074577-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-4154074577-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-4154074577-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-4154074577-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4154074577-r6" x="1159" y="288.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-11)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="288.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-11)">
+</text><text class="terminal-4154074577-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-12)">│</text><text class="terminal-4154074577-r6" x="1159" y="312.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-12)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="312.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-12)">
+</text><text class="terminal-4154074577-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-13)">│</text><text class="terminal-4154074577-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-4154074577-line-13)">-i</text><text class="terminal-4154074577-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-13)">-</text><text class="terminal-4154074577-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-4154074577-line-13)">-i</text><text class="terminal-4154074577-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-4154074577-line-13)">nteractive</text><text class="terminal-4154074577-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-4154074577-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-4154074577-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-4154074577-line-13)">smol</text><text class="terminal-4154074577-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-4154074577-line-13)">-k</text><text class="terminal-4154074577-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-4154074577-line-13)">8s</text><text class="terminal-4154074577-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-4154074577-line-13)">-l</text><text class="terminal-4154074577-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-4154074577-line-13)">ab</text><text class="terminal-4154074577-r6" x="1159" y="337.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-13)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="337.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-13)">
+</text><text class="terminal-4154074577-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-14)">│</text><text class="terminal-4154074577-r6" x="1159" y="361.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-14)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="361.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-14)">
+</text><text class="terminal-4154074577-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-4154074577-line-15)">│</text><text class="terminal-4154074577-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-4154074577-line-15)">-v</text><text class="terminal-4154074577-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-4154074577-line-15)">-</text><text class="terminal-4154074577-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-4154074577-line-15)">-v</text><text class="terminal-4154074577-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-4154074577-line-15)">ersion</text><text class="terminal-4154074577-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-4154074577-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-4154074577-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-4154074577-line-15)">smol</text><text class="terminal-4154074577-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-4154074577-line-15)">-k</text><text class="terminal-4154074577-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-4154074577-line-15)">8s</text><text class="terminal-4154074577-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-4154074577-line-15)">-l</text><text class="terminal-4154074577-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-4154074577-line-15)">ab</text><text class="terminal-4154074577-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-4154074577-line-15)">&#160;(v5.5.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4154074577-r6" x="1159" y="386" textLength="12.2" clip-path="url(#terminal-4154074577-line-15)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="386" textLength="12.2" clip-path="url(#terminal-4154074577-line-15)">
+</text><text class="terminal-4154074577-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-16)">│</text><text class="terminal-4154074577-r6" x="1159" y="410.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-16)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="410.4" textLength="12.2" clip-path="url(#terminal-4154074577-line-16)">
+</text><text class="terminal-4154074577-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-17)">│</text><text class="terminal-4154074577-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-4154074577-line-17)">-f</text><text class="terminal-4154074577-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-17)">-</text><text class="terminal-4154074577-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-4154074577-line-17)">-f</text><text class="terminal-4154074577-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-4154074577-line-17)">inal_cmd</text><text class="terminal-4154074577-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-4154074577-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-4154074577-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-4154074577-line-17)">smol</text><text class="terminal-4154074577-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-4154074577-line-17)">-k</text><text class="terminal-4154074577-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-4154074577-line-17)">8s</text><text class="terminal-4154074577-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-4154074577-line-17)">-l</text><text class="terminal-4154074577-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-4154074577-line-17)">ab</text><text class="terminal-4154074577-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-4154074577-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-4154074577-r6" x="1159" y="434.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-17)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="434.8" textLength="12.2" clip-path="url(#terminal-4154074577-line-17)">
+</text><text class="terminal-4154074577-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-18)">│</text><text class="terminal-4154074577-r6" x="1159" y="459.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-18)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="459.2" textLength="12.2" clip-path="url(#terminal-4154074577-line-18)">
+</text><text class="terminal-4154074577-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-19)">│</text><text class="terminal-4154074577-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-19)">-h</text><text class="terminal-4154074577-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-19)">-</text><text class="terminal-4154074577-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-4154074577-line-19)">-h</text><text class="terminal-4154074577-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-4154074577-line-19)">elp</text><text class="terminal-4154074577-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-4154074577-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4154074577-r6" x="1159" y="483.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-19)">│</text><text class="terminal-4154074577-r1" x="1171.2" y="483.6" textLength="12.2" clip-path="url(#terminal-4154074577-line-19)">
+</text><text class="terminal-4154074577-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-4154074577-line-20)">╰─</text><text class="terminal-4154074577-r6" x="24.4" y="508" textLength="500.2" clip-path="url(#terminal-4154074577-line-20)">─────────────────────────────────────────</text><text class="terminal-4154074577-r6" x="524.6" y="508" textLength="109.8" clip-path="url(#terminal-4154074577-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-4154074577-r6" x="634.4" y="508" textLength="500.2" clip-path="url(#terminal-4154074577-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-4154074577-r6" x="1146.8" y="508" textLength="24.4" clip-path="url(#terminal-4154074577-line-20)">─╯</text><text class="terminal-4154074577-r1" x="1171.2" y="508" textLength="12.2" clip-path="url(#terminal-4154074577-line-20)">
 </text>
     </g>
     </g>

--- a/poetry.lock
+++ b/poetry.lock
@@ -1011,18 +1011,18 @@ dev = ["flake8", "mypy", "pdoc3"]
 
 [[package]]
 name = "filelock"
-version = "3.14.0"
+version = "3.15.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.14.0-py3-none-any.whl", hash = "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f"},
-    {file = "filelock-3.14.0.tar.gz", hash = "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"},
+    {file = "filelock-3.15.1-py3-none-any.whl", hash = "sha256:71b3102950e91dfc1bb4209b64be4dc8854f40e5f534428d8684f953ac847fac"},
+    {file = "filelock-3.15.1.tar.gz", hash = "sha256:58a2549afdf9e02e10720eaa4d4470f56386d7a6f72edd7d0596337af8ed7ad8"},
 ]
 
 [package.extras]
 docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
@@ -1656,13 +1656,13 @@ files = [
 
 [[package]]
 name = "kubernetes"
-version = "29.0.0"
+version = "30.1.0"
 description = "Kubernetes python client"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "kubernetes-29.0.0-py2.py3-none-any.whl", hash = "sha256:ab8cb0e0576ccdfb71886366efb102c6a20f268d817be065ce7f9909c631e43e"},
-    {file = "kubernetes-29.0.0.tar.gz", hash = "sha256:c4812e227ae74d07d53c88293e564e54b850452715a59a927e7e1bc6b9a60459"},
+    {file = "kubernetes-30.1.0-py2.py3-none-any.whl", hash = "sha256:e212e8b7579031dd2e512168b617373bc1e03888d41ac4e04039240a292d478d"},
+    {file = "kubernetes-30.1.0.tar.gz", hash = "sha256:41e4c77af9f28e7a6c314e3bd06a8c6229ddd787cad684e0ab9f69b498e98ebc"},
 ]
 
 [package.dependencies]
@@ -2419,13 +2419,13 @@ tbb = "==2021.*"
 
 [[package]]
 name = "more-itertools"
-version = "10.2.0"
+version = "10.3.0"
 description = "More routines for operating on iterables, beyond itertools"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "more-itertools-10.2.0.tar.gz", hash = "sha256:8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1"},
-    {file = "more_itertools-10.2.0-py3-none-any.whl", hash = "sha256:686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684"},
+    {file = "more-itertools-10.3.0.tar.gz", hash = "sha256:e5d93ef411224fbcef366a6e8ddc4c5781bc6359d43412a65dd5964e46111463"},
+    {file = "more_itertools-10.3.0-py3-none-any.whl", hash = "sha256:ea6a02e24a9161e51faad17a8782b92a0df82c12c1c8886fec7f0c3fa1a1b320"},
 ]
 
 [[package]]
@@ -2922,13 +2922,13 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "packaging"
-version = "24.0"
+version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
-    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
 
 [[package]]
@@ -3167,22 +3167,22 @@ murmurhash = ">=0.28.0,<1.1.0"
 
 [[package]]
 name = "protobuf"
-version = "5.27.1"
+version = "4.25.3"
 description = ""
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "protobuf-5.27.1-cp310-abi3-win32.whl", hash = "sha256:3adc15ec0ff35c5b2d0992f9345b04a540c1e73bfee3ff1643db43cc1d734333"},
-    {file = "protobuf-5.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:25236b69ab4ce1bec413fd4b68a15ef8141794427e0b4dc173e9d5d9dffc3bcd"},
-    {file = "protobuf-5.27.1-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4e38fc29d7df32e01a41cf118b5a968b1efd46b9c41ff515234e794011c78b17"},
-    {file = "protobuf-5.27.1-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:917ed03c3eb8a2d51c3496359f5b53b4e4b7e40edfbdd3d3f34336e0eef6825a"},
-    {file = "protobuf-5.27.1-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:ee52874a9e69a30271649be88ecbe69d374232e8fd0b4e4b0aaaa87f429f1631"},
-    {file = "protobuf-5.27.1-cp38-cp38-win32.whl", hash = "sha256:7a97b9c5aed86b9ca289eb5148df6c208ab5bb6906930590961e08f097258107"},
-    {file = "protobuf-5.27.1-cp38-cp38-win_amd64.whl", hash = "sha256:f6abd0f69968792da7460d3c2cfa7d94fd74e1c21df321eb6345b963f9ec3d8d"},
-    {file = "protobuf-5.27.1-cp39-cp39-win32.whl", hash = "sha256:dfddb7537f789002cc4eb00752c92e67885badcc7005566f2c5de9d969d3282d"},
-    {file = "protobuf-5.27.1-cp39-cp39-win_amd64.whl", hash = "sha256:39309898b912ca6febb0084ea912e976482834f401be35840a008da12d189340"},
-    {file = "protobuf-5.27.1-py3-none-any.whl", hash = "sha256:4ac7249a1530a2ed50e24201d6630125ced04b30619262f06224616e0030b6cf"},
-    {file = "protobuf-5.27.1.tar.gz", hash = "sha256:df5e5b8e39b7d1c25b186ffdf9f44f40f810bbcc9d2b71d9d3156fee5a9adf15"},
+    {file = "protobuf-4.25.3-cp310-abi3-win32.whl", hash = "sha256:d4198877797a83cbfe9bffa3803602bbe1625dc30d8a097365dbc762e5790faa"},
+    {file = "protobuf-4.25.3-cp310-abi3-win_amd64.whl", hash = "sha256:209ba4cc916bab46f64e56b85b090607a676f66b473e6b762e6f1d9d591eb2e8"},
+    {file = "protobuf-4.25.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:f1279ab38ecbfae7e456a108c5c0681e4956d5b1090027c1de0f934dfdb4b35c"},
+    {file = "protobuf-4.25.3-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:e7cb0ae90dd83727f0c0718634ed56837bfeeee29a5f82a7514c03ee1364c019"},
+    {file = "protobuf-4.25.3-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:7c8daa26095f82482307bc717364e7c13f4f1c99659be82890dcfc215194554d"},
+    {file = "protobuf-4.25.3-cp38-cp38-win32.whl", hash = "sha256:f4f118245c4a087776e0a8408be33cf09f6c547442c00395fbfb116fac2f8ac2"},
+    {file = "protobuf-4.25.3-cp38-cp38-win_amd64.whl", hash = "sha256:c053062984e61144385022e53678fbded7aea14ebb3e0305ae3592fb219ccfa4"},
+    {file = "protobuf-4.25.3-cp39-cp39-win32.whl", hash = "sha256:19b270aeaa0099f16d3ca02628546b8baefe2955bbe23224aaf856134eccf1e4"},
+    {file = "protobuf-4.25.3-cp39-cp39-win_amd64.whl", hash = "sha256:e3c97a1555fd6388f857770ff8b9703083de6bf1f9274a002a332d65fbb56c8c"},
+    {file = "protobuf-4.25.3-py3-none-any.whl", hash = "sha256:f0700d54bcf45424477e46a9f0944155b46fb0639d69728739c0e47bab83f2b9"},
+    {file = "protobuf-4.25.3.tar.gz", hash = "sha256:25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c"},
 ]
 
 [[package]]
@@ -3292,13 +3292,13 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.7.3"
+version = "2.7.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.7.3-py3-none-any.whl", hash = "sha256:ea91b002777bf643bb20dd717c028ec43216b24a6001a280f83877fd2655d0b4"},
-    {file = "pydantic-2.7.3.tar.gz", hash = "sha256:c46c76a40bb1296728d7a8b99aa73dd70a48c3510111ff290034f860c99c419e"},
+    {file = "pydantic-2.7.4-py3-none-any.whl", hash = "sha256:ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0"},
+    {file = "pydantic-2.7.4.tar.gz", hash = "sha256:0c84efd9548d545f63ac0060c1e4d39bb9b14db8b3c0652338aecc07b5adec52"},
 ]
 
 [package.dependencies]
@@ -4624,12 +4624,12 @@ files = [
 
 [[package]]
 name = "tensorboard"
-version = "2.16.2"
+version = "2.17.0"
 description = "TensorBoard lets you watch Tensors Flow"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "tensorboard-2.16.2-py3-none-any.whl", hash = "sha256:9f2b4e7dad86667615c0e5cd072f1ea8403fc032a299f0072d6f74855775cc45"},
+    {file = "tensorboard-2.17.0-py3-none-any.whl", hash = "sha256:859a499a9b1fb68a058858964486627100b71fcb21646861c61d31846a6478fb"},
 ]
 
 [package.dependencies]
@@ -4637,7 +4637,7 @@ absl-py = ">=0.4"
 grpcio = ">=1.48.2"
 markdown = ">=2.6.8"
 numpy = ">=1.12.0"
-protobuf = ">=3.19.6,<4.24.0 || >4.24.0"
+protobuf = ">=3.19.6,<4.24.0 || >4.24.0,<5.0.0"
 setuptools = ">=41.0.0"
 six = ">1.9"
 tensorboard-data-server = ">=0.7.0,<0.8.0"
@@ -4657,13 +4657,13 @@ files = [
 
 [[package]]
 name = "textual"
-version = "0.65.2"
+version = "0.67.1"
 description = "Modern Text User Interface framework"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "textual-0.65.2-py3-none-any.whl", hash = "sha256:f01ce9ee3d2a613c63b9255900bf5a709b9ff7931d54d42f438e15495fa4ad3c"},
-    {file = "textual-0.65.2.tar.gz", hash = "sha256:05d4d39eedffac977b9bce9bea307dfefefdaaaa5081722549472cbb1d32e53f"},
+    {file = "textual-0.67.1-py3-none-any.whl", hash = "sha256:6c65e37f2114b5c8d74499586769aee763c14238a7671e0d0cf823b5f47ee6ac"},
+    {file = "textual-0.67.1.tar.gz", hash = "sha256:9d8708b2d1bf82de800b7da2202de26e6059d6106c67bf91e47b8a4763b3e8f5"},
 ]
 
 [package.dependencies]
@@ -5147,13 +5147,13 @@ typing-extensions = ">=3.7.4.3"
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.1"
+version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.12.1-py3-none-any.whl", hash = "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a"},
-    {file = "typing_extensions-4.12.1.tar.gz", hash = "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"},
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
@@ -5548,4 +5548,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "fc24391d15828561c8d4b4c3d396dbebdbadc95cc1182a9cbf3226e55f773af3"
+content-hash = "0caa27b6c921cfb584b4dc158f802f230be41c2c686b61377112d714ef48e520"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "5.4.3"
+version       = "5.5.0"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]
@@ -33,7 +33,7 @@ include       = ["smol_k8s_lab/config/kind/kind_cluster_config.yaml",
 bcrypt             = "^4.1"
 click              = "^8.1"
 cryptography       = "^42.0"
-kubernetes         = "^29"
+kubernetes         = "^30"
 minio              = "^7.2"
 pyfiglet           = "^1.0"
 pyjwt              = "^2.8"
@@ -43,7 +43,7 @@ requests           = "^2.32"
 rich               = "^13.0"
 ruamel-yaml        = "^0.18"
 ruamel-yaml-string = "^0.1"
-textual            = "^0.65"
+textual            = "^0.67"
 xdg-base-dirs      = "^6.0"
 pygame             = "^2.5"
 python-ulid        = "^2.6"

--- a/smol_k8s_lab/k8s_apps/social/matrix.py
+++ b/smol_k8s_lab/k8s_apps/social/matrix.py
@@ -250,25 +250,41 @@ def refresh_bweso(argocd: ArgoCD, matrix_hostname: str, bitwarden: BwCLI):
             f"matrix-pgsql-credentials-{matrix_hostname}", False
             )[0]['id']
 
-    sync_db_id = bitwarden.get_item(
-            f"syncv3-pgsql-credentials-{matrix_hostname}", False
-            )[0]['id']
-
-    mas_db_id = bitwarden.get_item(
-            f"mas-pgsql-credentials-{matrix_hostname}", False
-            )[0]['id']
-
-    mas_id = bitwarden.get_item(
-            f"matrix-authentication-service-credentials-{matrix_hostname}", False
-            )[0]['id']
-
-    sync_id = bitwarden.get_item(
-            f"matrix-syncv3-credentials-{matrix_hostname}", False
-            )[0]['id']
-
     oidc_id = bitwarden.get_item(
             f"matrix-oidc-credentials-{matrix_hostname}", False
             )[0]
+
+    try:
+        sync_db_id = bitwarden.get_item(
+                f"syncv3-pgsql-credentials-{matrix_hostname}", False
+                )[0]['id']
+    except TypeError:
+        log.info("No matrix sync db id found")
+        sync_db_id = "Not Applicable"
+
+    try:
+        mas_db_id = bitwarden.get_item(
+                f"mas-pgsql-credentials-{matrix_hostname}", False
+                )[0]['id']
+    except TypeError:
+        log.info("No matrix mas db id found")
+        mas_db_id = "Not Applicable"
+
+    try:
+        mas_id = bitwarden.get_item(
+                f"matrix-authentication-service-credentials-{matrix_hostname}", False
+                )[0]['id']
+    except TypeError:
+        log.info("No matrix mas id found")
+        mas_id = "Not Applicable"
+
+    try:
+        sync_id = bitwarden.get_item(
+                f"matrix-syncv3-credentials-{matrix_hostname}", False
+                )[0]['id']
+    except TypeError:
+        log.info("No matrix sync id found")
+        sync_id = "Not Applicable"
 
     # identity provider name and id are nested in the oidc item fields
     for field in oidc_id['fields']:

--- a/smol_k8s_lab/utils/rich_cli/help_text.py
+++ b/smol_k8s_lab/utils/rich_cli/help_text.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
 
-from smol_k8s_lab.constants import VERSION, XDG_CONFIG_FILE
+from smol_k8s_lab.constants import VERSION, XDG_CONFIG_FILE, PWD
 
 
 RECORD = environ.get("SMOL_SCREENSHOT", False)
@@ -138,4 +138,5 @@ class RichCommand(click.Command):
 
         # I use this to print a pretty svg at the end sometimes
         if RECORD:
-            console.save_svg("docs/assets/images/screenshots/help_text.svg", title="term")
+            console.save_svg(f"{PWD}/../docs/assets/images/screenshots/help_text.svg",
+                             title="term")


### PR DESCRIPTION
- closes #256 
- closes #254
- fixes issue where if you weren't using the new matrix beta, and you synced matrix, it failed looking for sliding sync and MAS related bitwarden item IDs. This was only present on a second run of smol-k8s-lab after matrix had been enabled and installed as an Argo CD app.