### PR TITLE
fix up zitadel backups/restores and always store the zitadel admin sa secret in bitwarden if possible

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1409 562.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1165 562.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,131 +19,131 @@
         font-weight: 700;
     }
 
-    .terminal-1434817194-matrix {
+    .terminal-737724939-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1434817194-title {
+    .terminal-737724939-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1434817194-r1 { fill: #c5c8c6 }
-.terminal-1434817194-r2 { fill: #5f87ff }
-.terminal-1434817194-r3 { fill: #5f87af;font-style: italic; }
-.terminal-1434817194-r4 { fill: #5f87af }
-.terminal-1434817194-r5 { fill: #8787ff }
-.terminal-1434817194-r6 { fill: #afafff }
-.terminal-1434817194-r7 { fill: #87afff }
-.terminal-1434817194-r8 { fill: #afafff;font-weight: bold }
-.terminal-1434817194-r9 { fill: #868887 }
-.terminal-1434817194-r10 { fill: #6179a9 }
-.terminal-1434817194-r11 { fill: #6161a9 }
-.terminal-1434817194-r12 { fill: #7979a9;font-weight: bold }
-.terminal-1434817194-r13 { fill: #4961a9 }
+    .terminal-737724939-r1 { fill: #c5c8c6 }
+.terminal-737724939-r2 { fill: #5f87ff }
+.terminal-737724939-r3 { fill: #5f87af;font-style: italic; }
+.terminal-737724939-r4 { fill: #5f87af }
+.terminal-737724939-r5 { fill: #8787ff }
+.terminal-737724939-r6 { fill: #afafff }
+.terminal-737724939-r7 { fill: #87afff }
+.terminal-737724939-r8 { fill: #afafff;font-weight: bold }
+.terminal-737724939-r9 { fill: #868887 }
+.terminal-737724939-r10 { fill: #6179a9 }
+.terminal-737724939-r11 { fill: #6161a9 }
+.terminal-737724939-r12 { fill: #7979a9;font-weight: bold }
+.terminal-737724939-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-1434817194-clip-terminal">
-      <rect x="0" y="0" width="1389.8" height="511.4" />
+    <clipPath id="terminal-737724939-clip-terminal">
+      <rect x="0" y="0" width="1145.8" height="511.4" />
     </clipPath>
-    <clipPath id="terminal-1434817194-line-0">
-    <rect x="0" y="1.5" width="1390.8" height="24.65"/>
+    <clipPath id="terminal-737724939-line-0">
+    <rect x="0" y="1.5" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-1">
-    <rect x="0" y="25.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-1">
+    <rect x="0" y="25.9" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-2">
-    <rect x="0" y="50.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-2">
+    <rect x="0" y="50.3" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-3">
-    <rect x="0" y="74.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-3">
+    <rect x="0" y="74.7" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-4">
-    <rect x="0" y="99.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-4">
+    <rect x="0" y="99.1" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-5">
-    <rect x="0" y="123.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-5">
+    <rect x="0" y="123.5" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-6">
-    <rect x="0" y="147.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-6">
+    <rect x="0" y="147.9" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-7">
-    <rect x="0" y="172.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-7">
+    <rect x="0" y="172.3" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-8">
-    <rect x="0" y="196.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-8">
+    <rect x="0" y="196.7" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-9">
-    <rect x="0" y="221.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-9">
+    <rect x="0" y="221.1" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-10">
-    <rect x="0" y="245.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-10">
+    <rect x="0" y="245.5" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-11">
-    <rect x="0" y="269.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-11">
+    <rect x="0" y="269.9" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-12">
-    <rect x="0" y="294.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-12">
+    <rect x="0" y="294.3" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-13">
-    <rect x="0" y="318.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-13">
+    <rect x="0" y="318.7" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-14">
-    <rect x="0" y="343.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-14">
+    <rect x="0" y="343.1" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-15">
-    <rect x="0" y="367.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-15">
+    <rect x="0" y="367.5" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-16">
-    <rect x="0" y="391.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-16">
+    <rect x="0" y="391.9" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-17">
-    <rect x="0" y="416.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-17">
+    <rect x="0" y="416.3" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-18">
-    <rect x="0" y="440.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-18">
+    <rect x="0" y="440.7" width="1146.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1434817194-line-19">
-    <rect x="0" y="465.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-737724939-line-19">
+    <rect x="0" y="465.1" width="1146.8" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1407" height="560.4" rx="8"/><text class="terminal-1434817194-title" fill="#c5c8c6" text-anchor="middle" x="703" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1163" height="560.4" rx="8"/><text class="terminal-737724939-title" fill="#c5c8c6" text-anchor="middle" x="581" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1434817194-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-737724939-clip-terminal)">
     
-    <g class="terminal-1434817194-matrix">
-    <text class="terminal-1434817194-r1" x="292.8" y="20" textLength="329.4" clip-path="url(#terminal-1434817194-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-1434817194-r2" x="634.4" y="20" textLength="146.4" clip-path="url(#terminal-1434817194-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-1434817194-r1" x="1390.8" y="20" textLength="12.2" clip-path="url(#terminal-1434817194-line-0)">
-</text><text class="terminal-1434817194-r1" x="1390.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-1)">
-</text><text class="terminal-1434817194-r3" x="292.8" y="68.8" textLength="793" clip-path="url(#terminal-1434817194-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-1434817194-r1" x="1390.8" y="68.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-2)">
-</text><text class="terminal-1434817194-r1" x="1390.8" y="93.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-3)">
-</text><text class="terminal-1434817194-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-1434817194-line-4)">Usage:</text><text class="terminal-1434817194-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-1434817194-line-4)">smol</text><text class="terminal-1434817194-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-4)">-k</text><text class="terminal-1434817194-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-4)">8s</text><text class="terminal-1434817194-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-4)">-l</text><text class="terminal-1434817194-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-4)">ab</text><text class="terminal-1434817194-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1434817194-line-4)">[OPTIONS]</text><text class="terminal-1434817194-r1" x="1390.8" y="117.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-4)">
-</text><text class="terminal-1434817194-r1" x="1390.8" y="142" textLength="12.2" clip-path="url(#terminal-1434817194-line-5)">
-</text><text class="terminal-1434817194-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1434817194-line-6)">╭─</text><text class="terminal-1434817194-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-1434817194-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-1434817194-r6" x="219.6" y="166.4" textLength="1146.8" clip-path="url(#terminal-1434817194-line-6)">──────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1434817194-r6" x="1366.4" y="166.4" textLength="24.4" clip-path="url(#terminal-1434817194-line-6)">─╮</text><text class="terminal-1434817194-r1" x="1390.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-6)">
-</text><text class="terminal-1434817194-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-7)">│</text><text class="terminal-1434817194-r6" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-7)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-7)">
-</text><text class="terminal-1434817194-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-8)">│</text><text class="terminal-1434817194-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-1434817194-line-8)">-c</text><text class="terminal-1434817194-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-8)">-</text><text class="terminal-1434817194-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-1434817194-line-8)">-c</text><text class="terminal-1434817194-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-1434817194-line-8)">onfig</text><text class="terminal-1434817194-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-1434817194-line-8)">&#160;CONFIG_FILE</text><text class="terminal-1434817194-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-1434817194-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1434817194-r6" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-8)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-8)">
-</text><text class="terminal-1434817194-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-9)">│</text><text class="terminal-1434817194-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-1434817194-line-9)">Defaults&#160;to&#160;</text><text class="terminal-1434817194-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-1434817194-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-1434817194-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-1434817194-line-9)">smol</text><text class="terminal-1434817194-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-9)">-k</text><text class="terminal-1434817194-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-9)">8s</text><text class="terminal-1434817194-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-9)">-l</text><text class="terminal-1434817194-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-9)">ab</text><text class="terminal-1434817194-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-1434817194-line-9)">/config.yaml</text><text class="terminal-1434817194-r6" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-9)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-9)">
-</text><text class="terminal-1434817194-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1434817194-line-10)">│</text><text class="terminal-1434817194-r6" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-1434817194-line-10)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="264" textLength="12.2" clip-path="url(#terminal-1434817194-line-10)">
-</text><text class="terminal-1434817194-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-11)">│</text><text class="terminal-1434817194-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-1434817194-line-11)">-D</text><text class="terminal-1434817194-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-11)">-</text><text class="terminal-1434817194-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-1434817194-line-11)">-d</text><text class="terminal-1434817194-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-1434817194-line-11)">elete</text><text class="terminal-1434817194-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-1434817194-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-1434817194-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-1434817194-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1434817194-r6" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-11)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-11)">
-</text><text class="terminal-1434817194-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-12)">│</text><text class="terminal-1434817194-r6" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-12)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-12)">
-</text><text class="terminal-1434817194-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-13)">│</text><text class="terminal-1434817194-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1434817194-line-13)">-i</text><text class="terminal-1434817194-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-13)">-</text><text class="terminal-1434817194-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1434817194-line-13)">-i</text><text class="terminal-1434817194-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-1434817194-line-13)">nteractive</text><text class="terminal-1434817194-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-1434817194-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-1434817194-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-1434817194-line-13)">smol</text><text class="terminal-1434817194-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1434817194-line-13)">-k</text><text class="terminal-1434817194-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-1434817194-line-13)">8s</text><text class="terminal-1434817194-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1434817194-line-13)">-l</text><text class="terminal-1434817194-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-1434817194-line-13)">ab</text><text class="terminal-1434817194-r6" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-13)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-13)">
-</text><text class="terminal-1434817194-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-14)">│</text><text class="terminal-1434817194-r6" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-14)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-14)">
-</text><text class="terminal-1434817194-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1434817194-line-15)">│</text><text class="terminal-1434817194-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1434817194-line-15)">-v</text><text class="terminal-1434817194-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-1434817194-line-15)">-</text><text class="terminal-1434817194-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-1434817194-line-15)">-v</text><text class="terminal-1434817194-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-1434817194-line-15)">ersion</text><text class="terminal-1434817194-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-1434817194-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-1434817194-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-1434817194-line-15)">smol</text><text class="terminal-1434817194-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-1434817194-line-15)">-k</text><text class="terminal-1434817194-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-1434817194-line-15)">8s</text><text class="terminal-1434817194-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-1434817194-line-15)">-l</text><text class="terminal-1434817194-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-1434817194-line-15)">ab</text><text class="terminal-1434817194-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-1434817194-line-15)">&#160;(v5.5.1)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1434817194-r6" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-1434817194-line-15)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="386" textLength="12.2" clip-path="url(#terminal-1434817194-line-15)">
-</text><text class="terminal-1434817194-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-16)">│</text><text class="terminal-1434817194-r6" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-16)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1434817194-line-16)">
-</text><text class="terminal-1434817194-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-17)">│</text><text class="terminal-1434817194-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1434817194-line-17)">-f</text><text class="terminal-1434817194-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-17)">-</text><text class="terminal-1434817194-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1434817194-line-17)">-f</text><text class="terminal-1434817194-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-1434817194-line-17)">inal_cmd</text><text class="terminal-1434817194-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-1434817194-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-1434817194-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-1434817194-line-17)">smol</text><text class="terminal-1434817194-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1434817194-line-17)">-k</text><text class="terminal-1434817194-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-1434817194-line-17)">8s</text><text class="terminal-1434817194-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-1434817194-line-17)">-l</text><text class="terminal-1434817194-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1434817194-line-17)">ab</text><text class="terminal-1434817194-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-1434817194-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-1434817194-r6" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-17)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="434.8" textLength="12.2" clip-path="url(#terminal-1434817194-line-17)">
-</text><text class="terminal-1434817194-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-18)">│</text><text class="terminal-1434817194-r6" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-18)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="459.2" textLength="12.2" clip-path="url(#terminal-1434817194-line-18)">
-</text><text class="terminal-1434817194-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-19)">│</text><text class="terminal-1434817194-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-19)">-h</text><text class="terminal-1434817194-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-19)">-</text><text class="terminal-1434817194-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-1434817194-line-19)">-h</text><text class="terminal-1434817194-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-1434817194-line-19)">elp</text><text class="terminal-1434817194-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-1434817194-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1434817194-r6" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-19)">│</text><text class="terminal-1434817194-r1" x="1390.8" y="483.6" textLength="12.2" clip-path="url(#terminal-1434817194-line-19)">
-</text><text class="terminal-1434817194-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-1434817194-line-20)">╰─</text><text class="terminal-1434817194-r6" x="24.4" y="508" textLength="719.8" clip-path="url(#terminal-1434817194-line-20)">───────────────────────────────────────────────────────────</text><text class="terminal-1434817194-r6" x="744.2" y="508" textLength="109.8" clip-path="url(#terminal-1434817194-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-1434817194-r6" x="854" y="508" textLength="500.2" clip-path="url(#terminal-1434817194-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-1434817194-r6" x="1366.4" y="508" textLength="24.4" clip-path="url(#terminal-1434817194-line-20)">─╯</text><text class="terminal-1434817194-r1" x="1390.8" y="508" textLength="12.2" clip-path="url(#terminal-1434817194-line-20)">
+    <g class="terminal-737724939-matrix">
+    <text class="terminal-737724939-r1" x="170.8" y="20" textLength="329.4" clip-path="url(#terminal-737724939-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-737724939-r2" x="512.4" y="20" textLength="146.4" clip-path="url(#terminal-737724939-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-737724939-r1" x="1146.8" y="20" textLength="12.2" clip-path="url(#terminal-737724939-line-0)">
+</text><text class="terminal-737724939-r1" x="1146.8" y="44.4" textLength="12.2" clip-path="url(#terminal-737724939-line-1)">
+</text><text class="terminal-737724939-r3" x="170.8" y="68.8" textLength="793" clip-path="url(#terminal-737724939-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-737724939-r1" x="1146.8" y="68.8" textLength="12.2" clip-path="url(#terminal-737724939-line-2)">
+</text><text class="terminal-737724939-r1" x="1146.8" y="93.2" textLength="12.2" clip-path="url(#terminal-737724939-line-3)">
+</text><text class="terminal-737724939-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-737724939-line-4)">Usage:</text><text class="terminal-737724939-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-737724939-line-4)">smol</text><text class="terminal-737724939-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-737724939-line-4)">-k</text><text class="terminal-737724939-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-737724939-line-4)">8s</text><text class="terminal-737724939-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-737724939-line-4)">-l</text><text class="terminal-737724939-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-737724939-line-4)">ab</text><text class="terminal-737724939-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-737724939-line-4)">[OPTIONS]</text><text class="terminal-737724939-r1" x="1146.8" y="117.6" textLength="12.2" clip-path="url(#terminal-737724939-line-4)">
+</text><text class="terminal-737724939-r1" x="1146.8" y="142" textLength="12.2" clip-path="url(#terminal-737724939-line-5)">
+</text><text class="terminal-737724939-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-737724939-line-6)">╭─</text><text class="terminal-737724939-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-737724939-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-737724939-r6" x="219.6" y="166.4" textLength="902.8" clip-path="url(#terminal-737724939-line-6)">──────────────────────────────────────────────────────────────────────────</text><text class="terminal-737724939-r6" x="1122.4" y="166.4" textLength="24.4" clip-path="url(#terminal-737724939-line-6)">─╮</text><text class="terminal-737724939-r1" x="1146.8" y="166.4" textLength="12.2" clip-path="url(#terminal-737724939-line-6)">
+</text><text class="terminal-737724939-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-737724939-line-7)">│</text><text class="terminal-737724939-r6" x="1134.6" y="190.8" textLength="12.2" clip-path="url(#terminal-737724939-line-7)">│</text><text class="terminal-737724939-r1" x="1146.8" y="190.8" textLength="12.2" clip-path="url(#terminal-737724939-line-7)">
+</text><text class="terminal-737724939-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-737724939-line-8)">│</text><text class="terminal-737724939-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-737724939-line-8)">-c</text><text class="terminal-737724939-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-737724939-line-8)">-</text><text class="terminal-737724939-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-737724939-line-8)">-c</text><text class="terminal-737724939-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-737724939-line-8)">onfig</text><text class="terminal-737724939-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-737724939-line-8)">&#160;CONFIG_FILE</text><text class="terminal-737724939-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-737724939-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-737724939-r6" x="1134.6" y="215.2" textLength="12.2" clip-path="url(#terminal-737724939-line-8)">│</text><text class="terminal-737724939-r1" x="1146.8" y="215.2" textLength="12.2" clip-path="url(#terminal-737724939-line-8)">
+</text><text class="terminal-737724939-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-737724939-line-9)">│</text><text class="terminal-737724939-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-737724939-line-9)">Defaults&#160;to&#160;</text><text class="terminal-737724939-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-737724939-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-737724939-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-737724939-line-9)">smol</text><text class="terminal-737724939-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-737724939-line-9)">-k</text><text class="terminal-737724939-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-737724939-line-9)">8s</text><text class="terminal-737724939-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-737724939-line-9)">-l</text><text class="terminal-737724939-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-737724939-line-9)">ab</text><text class="terminal-737724939-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-737724939-line-9)">/config.yaml</text><text class="terminal-737724939-r6" x="1134.6" y="239.6" textLength="12.2" clip-path="url(#terminal-737724939-line-9)">│</text><text class="terminal-737724939-r1" x="1146.8" y="239.6" textLength="12.2" clip-path="url(#terminal-737724939-line-9)">
+</text><text class="terminal-737724939-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-737724939-line-10)">│</text><text class="terminal-737724939-r6" x="1134.6" y="264" textLength="12.2" clip-path="url(#terminal-737724939-line-10)">│</text><text class="terminal-737724939-r1" x="1146.8" y="264" textLength="12.2" clip-path="url(#terminal-737724939-line-10)">
+</text><text class="terminal-737724939-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-737724939-line-11)">│</text><text class="terminal-737724939-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-737724939-line-11)">-D</text><text class="terminal-737724939-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-737724939-line-11)">-</text><text class="terminal-737724939-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-737724939-line-11)">-d</text><text class="terminal-737724939-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-737724939-line-11)">elete</text><text class="terminal-737724939-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-737724939-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-737724939-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-737724939-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-737724939-r6" x="1134.6" y="288.4" textLength="12.2" clip-path="url(#terminal-737724939-line-11)">│</text><text class="terminal-737724939-r1" x="1146.8" y="288.4" textLength="12.2" clip-path="url(#terminal-737724939-line-11)">
+</text><text class="terminal-737724939-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-737724939-line-12)">│</text><text class="terminal-737724939-r6" x="1134.6" y="312.8" textLength="12.2" clip-path="url(#terminal-737724939-line-12)">│</text><text class="terminal-737724939-r1" x="1146.8" y="312.8" textLength="12.2" clip-path="url(#terminal-737724939-line-12)">
+</text><text class="terminal-737724939-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-737724939-line-13)">│</text><text class="terminal-737724939-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-737724939-line-13)">-i</text><text class="terminal-737724939-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-737724939-line-13)">-</text><text class="terminal-737724939-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-737724939-line-13)">-i</text><text class="terminal-737724939-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-737724939-line-13)">nteractive</text><text class="terminal-737724939-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-737724939-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-737724939-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-737724939-line-13)">smol</text><text class="terminal-737724939-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-737724939-line-13)">-k</text><text class="terminal-737724939-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-737724939-line-13)">8s</text><text class="terminal-737724939-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-737724939-line-13)">-l</text><text class="terminal-737724939-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-737724939-line-13)">ab</text><text class="terminal-737724939-r6" x="1134.6" y="337.2" textLength="12.2" clip-path="url(#terminal-737724939-line-13)">│</text><text class="terminal-737724939-r1" x="1146.8" y="337.2" textLength="12.2" clip-path="url(#terminal-737724939-line-13)">
+</text><text class="terminal-737724939-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-737724939-line-14)">│</text><text class="terminal-737724939-r6" x="1134.6" y="361.6" textLength="12.2" clip-path="url(#terminal-737724939-line-14)">│</text><text class="terminal-737724939-r1" x="1146.8" y="361.6" textLength="12.2" clip-path="url(#terminal-737724939-line-14)">
+</text><text class="terminal-737724939-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-737724939-line-15)">│</text><text class="terminal-737724939-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-737724939-line-15)">-v</text><text class="terminal-737724939-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-737724939-line-15)">-</text><text class="terminal-737724939-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-737724939-line-15)">-v</text><text class="terminal-737724939-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-737724939-line-15)">ersion</text><text class="terminal-737724939-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-737724939-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-737724939-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-737724939-line-15)">smol</text><text class="terminal-737724939-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-737724939-line-15)">-k</text><text class="terminal-737724939-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-737724939-line-15)">8s</text><text class="terminal-737724939-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-737724939-line-15)">-l</text><text class="terminal-737724939-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-737724939-line-15)">ab</text><text class="terminal-737724939-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-737724939-line-15)">&#160;(v5.6.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-737724939-r6" x="1134.6" y="386" textLength="12.2" clip-path="url(#terminal-737724939-line-15)">│</text><text class="terminal-737724939-r1" x="1146.8" y="386" textLength="12.2" clip-path="url(#terminal-737724939-line-15)">
+</text><text class="terminal-737724939-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-737724939-line-16)">│</text><text class="terminal-737724939-r6" x="1134.6" y="410.4" textLength="12.2" clip-path="url(#terminal-737724939-line-16)">│</text><text class="terminal-737724939-r1" x="1146.8" y="410.4" textLength="12.2" clip-path="url(#terminal-737724939-line-16)">
+</text><text class="terminal-737724939-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-737724939-line-17)">│</text><text class="terminal-737724939-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-737724939-line-17)">-f</text><text class="terminal-737724939-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-737724939-line-17)">-</text><text class="terminal-737724939-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-737724939-line-17)">-f</text><text class="terminal-737724939-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-737724939-line-17)">inal_cmd</text><text class="terminal-737724939-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-737724939-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-737724939-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-737724939-line-17)">smol</text><text class="terminal-737724939-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-737724939-line-17)">-k</text><text class="terminal-737724939-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-737724939-line-17)">8s</text><text class="terminal-737724939-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-737724939-line-17)">-l</text><text class="terminal-737724939-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-737724939-line-17)">ab</text><text class="terminal-737724939-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-737724939-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-737724939-r6" x="1134.6" y="434.8" textLength="12.2" clip-path="url(#terminal-737724939-line-17)">│</text><text class="terminal-737724939-r1" x="1146.8" y="434.8" textLength="12.2" clip-path="url(#terminal-737724939-line-17)">
+</text><text class="terminal-737724939-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-737724939-line-18)">│</text><text class="terminal-737724939-r6" x="1134.6" y="459.2" textLength="12.2" clip-path="url(#terminal-737724939-line-18)">│</text><text class="terminal-737724939-r1" x="1146.8" y="459.2" textLength="12.2" clip-path="url(#terminal-737724939-line-18)">
+</text><text class="terminal-737724939-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-737724939-line-19)">│</text><text class="terminal-737724939-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-737724939-line-19)">-h</text><text class="terminal-737724939-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-737724939-line-19)">-</text><text class="terminal-737724939-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-737724939-line-19)">-h</text><text class="terminal-737724939-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-737724939-line-19)">elp</text><text class="terminal-737724939-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-737724939-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-737724939-r6" x="1134.6" y="483.6" textLength="12.2" clip-path="url(#terminal-737724939-line-19)">│</text><text class="terminal-737724939-r1" x="1146.8" y="483.6" textLength="12.2" clip-path="url(#terminal-737724939-line-19)">
+</text><text class="terminal-737724939-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-737724939-line-20)">╰─</text><text class="terminal-737724939-r6" x="24.4" y="508" textLength="475.8" clip-path="url(#terminal-737724939-line-20)">───────────────────────────────────────</text><text class="terminal-737724939-r6" x="500.2" y="508" textLength="109.8" clip-path="url(#terminal-737724939-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-737724939-r6" x="610" y="508" textLength="500.2" clip-path="url(#terminal-737724939-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-737724939-r6" x="1122.4" y="508" textLength="24.4" clip-path="url(#terminal-737724939-line-20)">─╯</text><text class="terminal-737724939-r1" x="1146.8" y="508" textLength="12.2" clip-path="url(#terminal-737724939-line-20)">
 </text>
     </g>
     </g>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "5.5.1"
+version       = "5.6.0"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/k8s_apps/identity_provider/zitadel.py
+++ b/smol_k8s_lab/k8s_apps/identity_provider/zitadel.py
@@ -144,7 +144,7 @@ def configure_zitadel(argocd: ArgoCD,
         if bitwarden and init_enabled:
             # get the zitadel service account private key json for generating a jwt
             private_key_dict = get_zitadel_admin_service_account(
-                    argocd.k8s_obj,
+                    argocd.k8s,
                     zitadel_hostname,
                     zitadel_namespace,
                     bitwarden)

--- a/smol_k8s_lab/k8s_apps/identity_provider/zitadel.py
+++ b/smol_k8s_lab/k8s_apps/identity_provider/zitadel.py
@@ -54,6 +54,8 @@ def configure_zitadel(argocd: ArgoCD,
         else:
             prefix = "Setting up"
 
+    zitadel_namespace = cfg['argo']['namespace']
+
     header(f"{prefix} [green]Zitadel[/], for your self hosted identity management",
            "👥")
 
@@ -75,8 +77,7 @@ def configure_zitadel(argocd: ArgoCD,
         backup_vals = process_backup_vals(cfg.get('backups', ''), 'zitadel', argocd)
 
         # first we make sure the namespace exists
-        namespace = cfg['argo']['namespace']
-        argocd.k8s.create_namespace(namespace)
+        argocd.k8s.create_namespace(zitadel_namespace)
 
         if bitwarden and not restore_enabled:
             setup_bitwarden_items(argocd,
@@ -92,18 +93,18 @@ def configure_zitadel(argocd: ArgoCD,
             # create the zitadel core key
             secret_dict = {'masterkey': create_password()}
             argocd.k8s.create_secret(name="zitadel-core-key",
-                                     namespace=namespace,
+                                     namespace=zitadel_namespace,
                                      str_data=secret_dict)
 
             # this is just for the db username
             argocd.k8s.create_secret(name="zitadel-db-credentials",
-                                     namespace=namespace,
+                                     namespace=zitadel_namespace,
                                      str_data={'username': 'zitadel'})
 
     if not app_installed and restore_enabled:
         restore_zitadel(argocd,
                         zitadel_hostname,
-                        namespace,
+                        zitadel_namespace,
                         cfg['argo'],
                         secrets,
                         restore_dict,
@@ -129,8 +130,10 @@ def configure_zitadel(argocd: ArgoCD,
         # Before initialization, we need to wait for zitadel's API to be up
         argocd.wait_for_app('zitadel', retry=True)
         argocd.wait_for_app('zitadel-web-app', retry=True)
+
         vouch_dict = initialize_zitadel(argocd,
                                         zitadel_hostname=zitadel_hostname,
+                                        zitadel_namespace=zitadel_namespace,
                                         api_tls_verify=api_tls_verify,
                                         user_dict=initial_user_dict,
                                         bitwarden=bitwarden)
@@ -140,15 +143,16 @@ def configure_zitadel(argocd: ArgoCD,
 
         if bitwarden and init_enabled:
             # get the zitadel service account private key json for generating a jwt
-            adm_secret_file = argocd.k8s.get_secret(
-                    'zitadel-admin-sa',
-                    'zitadel'
-                    )['data']['zitadel-admin-sa.json']
+            private_key_dict = get_zitadel_admin_service_account(
+                    argocd.k8s_obj,
+                    zitadel_hostname,
+                    zitadel_namespace,
+                    bitwarden)
 
             # setup and return the zitadel python api wrapper
             zitadel = Zitadel(
                     zitadel_hostname,
-                    loads(b64dec(str.encode(adm_secret_file)).decode('utf8')),
+                    private_key_dict,
                     api_tls_verify
                     )
             try:
@@ -173,8 +177,52 @@ def configure_zitadel(argocd: ArgoCD,
             return zitadel
 
 
+def get_zitadel_admin_service_account(k8s_obj,
+                                      zitadel_hostname: str,
+                                      zitadel_namespace: str = "zitadel",
+                                      bitwarden: BwCLI = None) -> dict | None:
+    """
+    Try to get the zitadel admin service account from k8s secret or bitwarden.
+    If it finds the admin service account secret, it returns a dict like:
+    {"keyId": "", "key": "", "userId": ""}
+    """
+    # get the zitadel service account private key json for generating a jwt
+    try:
+        # first, we try to get private key from a k8s secret in the zitadel ns
+        adm_secret = k8s_obj.get_secret('zitadel-admin-sa', zitadel_namespace)
+        adm_secret_file = adm_secret['data']['zitadel-admin-sa.json']
+        private_key_dict = loads(b64dec(str.encode(adm_secret_file)).decode('utf8'))
+    except Exception as e:
+        # if that fails, then we try to get the key from bitwarden
+        log.warn(f"Encountered error while getting secret: {e}")
+        if bitwarden:
+            log.info("Trying to get admin service account secret from bitwarden.")
+            adm_secret = bitwarden.get_item(
+                    f"zitadel-admin-service-account-{zitadel_hostname}"
+                    )[0]
+            private_key_dict = {"keyId": adm_secret['fields'][0]['value'],
+                                "key": adm_secret['login']['password'],
+                                "userId": adm_secret['login']['username']}
+        else:
+            return None
+    else:
+        # if we find the key in a k8s secret, we try to put into bitwarden, so
+        # that if the whole namespace is blown away, we still have access to it
+        key_id_field = create_custom_field("keyId", private_key_dict['keyId'])
+        bitwarden.create_login(
+            name='zitadel-admin-service-account',
+            item_url=zitadel_hostname,
+            user=private_key_dict['userId'],
+            password=private_key_dict['key'],
+            fields=[key_id_field]
+            )
+
+    return private_key_dict
+
+
 def initialize_zitadel(argocd: ArgoCD,
                        zitadel_hostname: str,
+                       zitadel_namespace: str = "zitadel",
                        api_tls_verify: bool = False,
                        user_dict: dict = {},
                        bitwarden: BwCLI = None) -> dict | None:
@@ -194,13 +242,15 @@ def initialize_zitadel(argocd: ArgoCD,
     argocd_hostname = argocd.hostname
 
     sub_header("Configuring zitadel as your OIDC SSO for Argo CD")
+    private_key_dict = get_zitadel_admin_service_account(k8s_obj,
+                                                         zitadel_hostname,
+                                                         zitadel_namespace,
+                                                         bitwarden)
+    if not private_key_dict:
+        log.error("No private key dict was recieved, can't initialize zitadel api")
 
-    # get the zitadel service account private key json for generating a jwt
-    adm_secret = k8s_obj.get_secret('zitadel-admin-sa', 'zitadel')
-    adm_secret_file = adm_secret['data']['zitadel-admin-sa.json']
-    private_key_obj = loads(b64dec(str.encode(adm_secret_file)).decode('utf8'))
     # setup the zitadel python api wrapper
-    zitadel =  Zitadel(zitadel_hostname, private_key_obj, api_tls_verify)
+    zitadel =  Zitadel(zitadel_hostname, private_key_dict, api_tls_verify)
 
     # create our first project
     project_name = user_dict.pop('project')
@@ -413,10 +463,7 @@ def restore_zitadel(argocd: ArgoCD,
         refresh_bitwarden(argocd, zitadel_hostname, bitwarden)
 
         # apply the external secrets so we can immediately use them for restores
-        # ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
-        # WARNING: change this back to main when done testing
-        # ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
-        ref = "add-pvc-helm-chart-for-zitadel"
+        ref = "main"
         external_secrets_yaml = (
                 "https://raw.githubusercontent.com/small-hack/argocd-apps/"
                 f"{ref}/zitadel/app_of_apps/external_secrets_argocd_appset.yaml"
@@ -437,10 +484,9 @@ def restore_zitadel(argocd: ArgoCD,
     # then we create all the seaweedfs pvcs we lost and restore them
     snapshot_ids = restore_dict['restic_snapshot_ids']
     restore_seaweedfs(
-            argocd.k8s,
+            argocd,
             'zitadel',
             zitadel_namespace,
-            argocd.namespace,
             s3_backup_endpoint,
             s3_backup_bucket,
             access_key_id,
@@ -458,7 +504,8 @@ def restore_zitadel(argocd: ArgoCD,
     if restore_dict.get("cnpg_restore", False):
         psql_version = restore_dict.get("postgresql_version", 16)
         s3_endpoint = secrets.get('s3_endpoint', "")
-        restore_cnpg_cluster('zitadel',
+        restore_cnpg_cluster(argocd.k8s,
+                             'zitadel',
                              zitadel_namespace,
                              pgsql_cluster_name,
                              psql_version,

--- a/smol_k8s_lab/utils/minio_lib.py
+++ b/smol_k8s_lab/utils/minio_lib.py
@@ -57,6 +57,19 @@ class BetterMinio:
 
         return self.client.list_objects(**obj_args)
 
+    def delete_object(self,
+                      bucket_name: str,
+                      object_name: str,
+                      recursive: bool = False):
+        """
+        delete an object from a bucket
+        """
+        if recursive:
+            objects = self.list_object(bucket_name, object_name, recursive=True)
+            self.client.remove_objects(bucket_name, objects)
+        else:
+            self.client.remove_object(bucket_name, object_name)
+
     def create_access_credentials(self, access_key: str) -> str:
         """
         given an access key name, we create minio access credentials


### PR DESCRIPTION
So, we hadn't actually tested a full restore of zitadel, only backups before. We discovered that we crucially need to save the zitadel admin service account private key that zitadel generates, because it won't generate another one. Due to that, we now immediately store that key in bitwarden, so that users can't safely destroy the whole namespace and still restore. We also found some other minor bugs with the zitadel restores including calling the restore functions improperly, and using an old feature branch for restoring secrets.

We also now clear the local seaweedfs postgresql bucket after we restore anything using cnpg operator for postgresql. This affects nextcloud, matrix, zitadel, and mastodon. We do this, because if we don't future backups after that restore will fail, as the backup process expects that bucket to be empty, which is really weird and confusing. You'll still always have remote backups, so it's not a huge deal, but this hack is the only way outside of keeping track of the backup bucket name and renaming it, which can get out of hand, as we'd need to store cache or look up the bucket each time we did backup, and that feels bad?

We've managed to restore a production cluster, but only from a manual backup that happened on May 10th, which is pretty bad :/ We'll have to figure out why our backups were failing nightly, and then the next task should really be setting up proper alerting to matrix so we get alerts when backups are failing :facepalm: Will report more details after we fix backups Update: it was because we didn't clear the cnpg backup bucket properly before, but we've fixed that now :)