### PR TITLE
Set up grafana oidc directly via zitadel instead of using vouch if `init.enabled`; also upgrade textual dep to `0.72.0`

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1409 562.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1531 562.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,131 +19,131 @@
         font-weight: 700;
     }
 
-    .terminal-18059957-matrix {
+    .terminal-1660145454-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-18059957-title {
+    .terminal-1660145454-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-18059957-r1 { fill: #c5c8c6 }
-.terminal-18059957-r2 { fill: #5f87ff }
-.terminal-18059957-r3 { fill: #5f87af;font-style: italic; }
-.terminal-18059957-r4 { fill: #5f87af }
-.terminal-18059957-r5 { fill: #8787ff }
-.terminal-18059957-r6 { fill: #afafff }
-.terminal-18059957-r7 { fill: #87afff }
-.terminal-18059957-r8 { fill: #afafff;font-weight: bold }
-.terminal-18059957-r9 { fill: #868887 }
-.terminal-18059957-r10 { fill: #6179a9 }
-.terminal-18059957-r11 { fill: #6161a9 }
-.terminal-18059957-r12 { fill: #7979a9;font-weight: bold }
-.terminal-18059957-r13 { fill: #4961a9 }
+    .terminal-1660145454-r1 { fill: #c5c8c6 }
+.terminal-1660145454-r2 { fill: #5f87ff }
+.terminal-1660145454-r3 { fill: #5f87af;font-style: italic; }
+.terminal-1660145454-r4 { fill: #5f87af }
+.terminal-1660145454-r5 { fill: #8787ff }
+.terminal-1660145454-r6 { fill: #afafff }
+.terminal-1660145454-r7 { fill: #87afff }
+.terminal-1660145454-r8 { fill: #afafff;font-weight: bold }
+.terminal-1660145454-r9 { fill: #868887 }
+.terminal-1660145454-r10 { fill: #6179a9 }
+.terminal-1660145454-r11 { fill: #6161a9 }
+.terminal-1660145454-r12 { fill: #7979a9;font-weight: bold }
+.terminal-1660145454-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-18059957-clip-terminal">
-      <rect x="0" y="0" width="1389.8" height="511.4" />
+    <clipPath id="terminal-1660145454-clip-terminal">
+      <rect x="0" y="0" width="1511.8" height="511.4" />
     </clipPath>
-    <clipPath id="terminal-18059957-line-0">
-    <rect x="0" y="1.5" width="1390.8" height="24.65"/>
+    <clipPath id="terminal-1660145454-line-0">
+    <rect x="0" y="1.5" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-1">
-    <rect x="0" y="25.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-1">
+    <rect x="0" y="25.9" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-2">
-    <rect x="0" y="50.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-2">
+    <rect x="0" y="50.3" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-3">
-    <rect x="0" y="74.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-3">
+    <rect x="0" y="74.7" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-4">
-    <rect x="0" y="99.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-4">
+    <rect x="0" y="99.1" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-5">
-    <rect x="0" y="123.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-5">
+    <rect x="0" y="123.5" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-6">
-    <rect x="0" y="147.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-6">
+    <rect x="0" y="147.9" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-7">
-    <rect x="0" y="172.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-7">
+    <rect x="0" y="172.3" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-8">
-    <rect x="0" y="196.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-8">
+    <rect x="0" y="196.7" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-9">
-    <rect x="0" y="221.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-9">
+    <rect x="0" y="221.1" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-10">
-    <rect x="0" y="245.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-10">
+    <rect x="0" y="245.5" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-11">
-    <rect x="0" y="269.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-11">
+    <rect x="0" y="269.9" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-12">
-    <rect x="0" y="294.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-12">
+    <rect x="0" y="294.3" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-13">
-    <rect x="0" y="318.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-13">
+    <rect x="0" y="318.7" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-14">
-    <rect x="0" y="343.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-14">
+    <rect x="0" y="343.1" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-15">
-    <rect x="0" y="367.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-15">
+    <rect x="0" y="367.5" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-16">
-    <rect x="0" y="391.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-16">
+    <rect x="0" y="391.9" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-17">
-    <rect x="0" y="416.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-17">
+    <rect x="0" y="416.3" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-18">
-    <rect x="0" y="440.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-18">
+    <rect x="0" y="440.7" width="1512.8" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-18059957-line-19">
-    <rect x="0" y="465.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-1660145454-line-19">
+    <rect x="0" y="465.1" width="1512.8" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1407" height="560.4" rx="8"/><text class="terminal-18059957-title" fill="#c5c8c6" text-anchor="middle" x="703" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1529" height="560.4" rx="8"/><text class="terminal-1660145454-title" fill="#c5c8c6" text-anchor="middle" x="764" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-18059957-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1660145454-clip-terminal)">
     
-    <g class="terminal-18059957-matrix">
-    <text class="terminal-18059957-r1" x="292.8" y="20" textLength="329.4" clip-path="url(#terminal-18059957-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-18059957-r2" x="634.4" y="20" textLength="146.4" clip-path="url(#terminal-18059957-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-18059957-r1" x="1390.8" y="20" textLength="12.2" clip-path="url(#terminal-18059957-line-0)">
-</text><text class="terminal-18059957-r1" x="1390.8" y="44.4" textLength="12.2" clip-path="url(#terminal-18059957-line-1)">
-</text><text class="terminal-18059957-r3" x="292.8" y="68.8" textLength="793" clip-path="url(#terminal-18059957-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-18059957-r1" x="1390.8" y="68.8" textLength="12.2" clip-path="url(#terminal-18059957-line-2)">
-</text><text class="terminal-18059957-r1" x="1390.8" y="93.2" textLength="12.2" clip-path="url(#terminal-18059957-line-3)">
-</text><text class="terminal-18059957-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-18059957-line-4)">Usage:</text><text class="terminal-18059957-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-18059957-line-4)">smol</text><text class="terminal-18059957-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-18059957-line-4)">-k</text><text class="terminal-18059957-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-18059957-line-4)">8s</text><text class="terminal-18059957-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-18059957-line-4)">-l</text><text class="terminal-18059957-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-18059957-line-4)">ab</text><text class="terminal-18059957-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-18059957-line-4)">[OPTIONS]</text><text class="terminal-18059957-r1" x="1390.8" y="117.6" textLength="12.2" clip-path="url(#terminal-18059957-line-4)">
-</text><text class="terminal-18059957-r1" x="1390.8" y="142" textLength="12.2" clip-path="url(#terminal-18059957-line-5)">
-</text><text class="terminal-18059957-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-18059957-line-6)">╭─</text><text class="terminal-18059957-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-18059957-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-18059957-r6" x="219.6" y="166.4" textLength="1146.8" clip-path="url(#terminal-18059957-line-6)">──────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-18059957-r6" x="1366.4" y="166.4" textLength="24.4" clip-path="url(#terminal-18059957-line-6)">─╮</text><text class="terminal-18059957-r1" x="1390.8" y="166.4" textLength="12.2" clip-path="url(#terminal-18059957-line-6)">
-</text><text class="terminal-18059957-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-18059957-line-7)">│</text><text class="terminal-18059957-r6" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-18059957-line-7)">│</text><text class="terminal-18059957-r1" x="1390.8" y="190.8" textLength="12.2" clip-path="url(#terminal-18059957-line-7)">
-</text><text class="terminal-18059957-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-18059957-line-8)">│</text><text class="terminal-18059957-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-18059957-line-8)">-c</text><text class="terminal-18059957-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-18059957-line-8)">-</text><text class="terminal-18059957-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-18059957-line-8)">-c</text><text class="terminal-18059957-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-18059957-line-8)">onfig</text><text class="terminal-18059957-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-18059957-line-8)">&#160;CONFIG_FILE</text><text class="terminal-18059957-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-18059957-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-18059957-r6" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-18059957-line-8)">│</text><text class="terminal-18059957-r1" x="1390.8" y="215.2" textLength="12.2" clip-path="url(#terminal-18059957-line-8)">
-</text><text class="terminal-18059957-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-18059957-line-9)">│</text><text class="terminal-18059957-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-18059957-line-9)">Defaults&#160;to&#160;</text><text class="terminal-18059957-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-18059957-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-18059957-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-18059957-line-9)">smol</text><text class="terminal-18059957-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-18059957-line-9)">-k</text><text class="terminal-18059957-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-18059957-line-9)">8s</text><text class="terminal-18059957-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-18059957-line-9)">-l</text><text class="terminal-18059957-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-18059957-line-9)">ab</text><text class="terminal-18059957-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-18059957-line-9)">/config.yaml</text><text class="terminal-18059957-r6" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-18059957-line-9)">│</text><text class="terminal-18059957-r1" x="1390.8" y="239.6" textLength="12.2" clip-path="url(#terminal-18059957-line-9)">
-</text><text class="terminal-18059957-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-18059957-line-10)">│</text><text class="terminal-18059957-r6" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-18059957-line-10)">│</text><text class="terminal-18059957-r1" x="1390.8" y="264" textLength="12.2" clip-path="url(#terminal-18059957-line-10)">
-</text><text class="terminal-18059957-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-18059957-line-11)">│</text><text class="terminal-18059957-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-18059957-line-11)">-D</text><text class="terminal-18059957-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-18059957-line-11)">-</text><text class="terminal-18059957-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-18059957-line-11)">-d</text><text class="terminal-18059957-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-18059957-line-11)">elete</text><text class="terminal-18059957-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-18059957-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-18059957-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-18059957-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-18059957-r6" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-18059957-line-11)">│</text><text class="terminal-18059957-r1" x="1390.8" y="288.4" textLength="12.2" clip-path="url(#terminal-18059957-line-11)">
-</text><text class="terminal-18059957-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-18059957-line-12)">│</text><text class="terminal-18059957-r6" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-18059957-line-12)">│</text><text class="terminal-18059957-r1" x="1390.8" y="312.8" textLength="12.2" clip-path="url(#terminal-18059957-line-12)">
-</text><text class="terminal-18059957-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-18059957-line-13)">│</text><text class="terminal-18059957-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-18059957-line-13)">-i</text><text class="terminal-18059957-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-18059957-line-13)">-</text><text class="terminal-18059957-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-18059957-line-13)">-i</text><text class="terminal-18059957-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-18059957-line-13)">nteractive</text><text class="terminal-18059957-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-18059957-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-18059957-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-18059957-line-13)">smol</text><text class="terminal-18059957-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-18059957-line-13)">-k</text><text class="terminal-18059957-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-18059957-line-13)">8s</text><text class="terminal-18059957-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-18059957-line-13)">-l</text><text class="terminal-18059957-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-18059957-line-13)">ab</text><text class="terminal-18059957-r6" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-18059957-line-13)">│</text><text class="terminal-18059957-r1" x="1390.8" y="337.2" textLength="12.2" clip-path="url(#terminal-18059957-line-13)">
-</text><text class="terminal-18059957-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-18059957-line-14)">│</text><text class="terminal-18059957-r6" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-18059957-line-14)">│</text><text class="terminal-18059957-r1" x="1390.8" y="361.6" textLength="12.2" clip-path="url(#terminal-18059957-line-14)">
-</text><text class="terminal-18059957-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-18059957-line-15)">│</text><text class="terminal-18059957-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-18059957-line-15)">-v</text><text class="terminal-18059957-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-18059957-line-15)">-</text><text class="terminal-18059957-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-18059957-line-15)">-v</text><text class="terminal-18059957-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-18059957-line-15)">ersion</text><text class="terminal-18059957-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-18059957-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-18059957-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-18059957-line-15)">smol</text><text class="terminal-18059957-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-18059957-line-15)">-k</text><text class="terminal-18059957-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-18059957-line-15)">8s</text><text class="terminal-18059957-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-18059957-line-15)">-l</text><text class="terminal-18059957-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-18059957-line-15)">ab</text><text class="terminal-18059957-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-18059957-line-15)">&#160;(v5.10.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-18059957-r6" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-18059957-line-15)">│</text><text class="terminal-18059957-r1" x="1390.8" y="386" textLength="12.2" clip-path="url(#terminal-18059957-line-15)">
-</text><text class="terminal-18059957-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-18059957-line-16)">│</text><text class="terminal-18059957-r6" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-18059957-line-16)">│</text><text class="terminal-18059957-r1" x="1390.8" y="410.4" textLength="12.2" clip-path="url(#terminal-18059957-line-16)">
-</text><text class="terminal-18059957-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-18059957-line-17)">│</text><text class="terminal-18059957-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-18059957-line-17)">-f</text><text class="terminal-18059957-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-18059957-line-17)">-</text><text class="terminal-18059957-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-18059957-line-17)">-f</text><text class="terminal-18059957-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-18059957-line-17)">inal_cmd</text><text class="terminal-18059957-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-18059957-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-18059957-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-18059957-line-17)">smol</text><text class="terminal-18059957-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-18059957-line-17)">-k</text><text class="terminal-18059957-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-18059957-line-17)">8s</text><text class="terminal-18059957-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-18059957-line-17)">-l</text><text class="terminal-18059957-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-18059957-line-17)">ab</text><text class="terminal-18059957-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-18059957-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-18059957-r6" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-18059957-line-17)">│</text><text class="terminal-18059957-r1" x="1390.8" y="434.8" textLength="12.2" clip-path="url(#terminal-18059957-line-17)">
-</text><text class="terminal-18059957-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-18059957-line-18)">│</text><text class="terminal-18059957-r6" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-18059957-line-18)">│</text><text class="terminal-18059957-r1" x="1390.8" y="459.2" textLength="12.2" clip-path="url(#terminal-18059957-line-18)">
-</text><text class="terminal-18059957-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-18059957-line-19)">│</text><text class="terminal-18059957-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-18059957-line-19)">-h</text><text class="terminal-18059957-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-18059957-line-19)">-</text><text class="terminal-18059957-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-18059957-line-19)">-h</text><text class="terminal-18059957-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-18059957-line-19)">elp</text><text class="terminal-18059957-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-18059957-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-18059957-r6" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-18059957-line-19)">│</text><text class="terminal-18059957-r1" x="1390.8" y="483.6" textLength="12.2" clip-path="url(#terminal-18059957-line-19)">
-</text><text class="terminal-18059957-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-18059957-line-20)">╰─</text><text class="terminal-18059957-r6" x="24.4" y="508" textLength="719.8" clip-path="url(#terminal-18059957-line-20)">───────────────────────────────────────────────────────────</text><text class="terminal-18059957-r6" x="744.2" y="508" textLength="109.8" clip-path="url(#terminal-18059957-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-18059957-r6" x="854" y="508" textLength="500.2" clip-path="url(#terminal-18059957-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-18059957-r6" x="1366.4" y="508" textLength="24.4" clip-path="url(#terminal-18059957-line-20)">─╯</text><text class="terminal-18059957-r1" x="1390.8" y="508" textLength="12.2" clip-path="url(#terminal-18059957-line-20)">
+    <g class="terminal-1660145454-matrix">
+    <text class="terminal-1660145454-r1" x="353.8" y="20" textLength="329.4" clip-path="url(#terminal-1660145454-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-1660145454-r2" x="695.4" y="20" textLength="146.4" clip-path="url(#terminal-1660145454-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-1660145454-r1" x="1512.8" y="20" textLength="12.2" clip-path="url(#terminal-1660145454-line-0)">
+</text><text class="terminal-1660145454-r1" x="1512.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-1)">
+</text><text class="terminal-1660145454-r3" x="353.8" y="68.8" textLength="793" clip-path="url(#terminal-1660145454-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-1660145454-r1" x="1512.8" y="68.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-2)">
+</text><text class="terminal-1660145454-r1" x="1512.8" y="93.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-3)">
+</text><text class="terminal-1660145454-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-1660145454-line-4)">Usage:</text><text class="terminal-1660145454-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-1660145454-line-4)">smol</text><text class="terminal-1660145454-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-4)">-k</text><text class="terminal-1660145454-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-4)">8s</text><text class="terminal-1660145454-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-4)">-l</text><text class="terminal-1660145454-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-4)">ab</text><text class="terminal-1660145454-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1660145454-line-4)">[OPTIONS]</text><text class="terminal-1660145454-r1" x="1512.8" y="117.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-4)">
+</text><text class="terminal-1660145454-r1" x="1512.8" y="142" textLength="12.2" clip-path="url(#terminal-1660145454-line-5)">
+</text><text class="terminal-1660145454-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1660145454-line-6)">╭─</text><text class="terminal-1660145454-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-1660145454-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-1660145454-r6" x="219.6" y="166.4" textLength="1268.8" clip-path="url(#terminal-1660145454-line-6)">────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1660145454-r6" x="1488.4" y="166.4" textLength="24.4" clip-path="url(#terminal-1660145454-line-6)">─╮</text><text class="terminal-1660145454-r1" x="1512.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-6)">
+</text><text class="terminal-1660145454-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-7)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="190.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-7)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-7)">
+</text><text class="terminal-1660145454-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-8)">│</text><text class="terminal-1660145454-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-8)">-c</text><text class="terminal-1660145454-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-8)">-</text><text class="terminal-1660145454-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-8)">-c</text><text class="terminal-1660145454-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-1660145454-line-8)">onfig</text><text class="terminal-1660145454-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-1660145454-line-8)">&#160;CONFIG_FILE</text><text class="terminal-1660145454-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-1660145454-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1660145454-r6" x="1500.6" y="215.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-8)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-8)">
+</text><text class="terminal-1660145454-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-9)">│</text><text class="terminal-1660145454-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-1660145454-line-9)">Defaults&#160;to&#160;</text><text class="terminal-1660145454-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-1660145454-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-1660145454-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-1660145454-line-9)">smol</text><text class="terminal-1660145454-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-9)">-k</text><text class="terminal-1660145454-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-9)">8s</text><text class="terminal-1660145454-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-9)">-l</text><text class="terminal-1660145454-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-9)">ab</text><text class="terminal-1660145454-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-1660145454-line-9)">/config.yaml</text><text class="terminal-1660145454-r6" x="1500.6" y="239.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-9)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-9)">
+</text><text class="terminal-1660145454-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1660145454-line-10)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="264" textLength="12.2" clip-path="url(#terminal-1660145454-line-10)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="264" textLength="12.2" clip-path="url(#terminal-1660145454-line-10)">
+</text><text class="terminal-1660145454-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-11)">│</text><text class="terminal-1660145454-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-1660145454-line-11)">-D</text><text class="terminal-1660145454-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-11)">-</text><text class="terminal-1660145454-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-1660145454-line-11)">-d</text><text class="terminal-1660145454-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-1660145454-line-11)">elete</text><text class="terminal-1660145454-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-1660145454-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-1660145454-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-1660145454-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1660145454-r6" x="1500.6" y="288.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-11)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-11)">
+</text><text class="terminal-1660145454-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-12)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="312.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-12)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-12)">
+</text><text class="terminal-1660145454-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-13)">│</text><text class="terminal-1660145454-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">-i</text><text class="terminal-1660145454-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-13)">-</text><text class="terminal-1660145454-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">-i</text><text class="terminal-1660145454-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-1660145454-line-13)">nteractive</text><text class="terminal-1660145454-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-1660145454-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-1660145454-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-1660145454-line-13)">smol</text><text class="terminal-1660145454-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">-k</text><text class="terminal-1660145454-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">8s</text><text class="terminal-1660145454-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">-l</text><text class="terminal-1660145454-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">ab</text><text class="terminal-1660145454-r6" x="1500.6" y="337.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-13)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-13)">
+</text><text class="terminal-1660145454-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-14)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="361.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-14)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-14)">
+</text><text class="terminal-1660145454-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1660145454-line-15)">│</text><text class="terminal-1660145454-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">-v</text><text class="terminal-1660145454-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-1660145454-line-15)">-</text><text class="terminal-1660145454-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">-v</text><text class="terminal-1660145454-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-1660145454-line-15)">ersion</text><text class="terminal-1660145454-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-1660145454-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-1660145454-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-1660145454-line-15)">smol</text><text class="terminal-1660145454-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">-k</text><text class="terminal-1660145454-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">8s</text><text class="terminal-1660145454-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">-l</text><text class="terminal-1660145454-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">ab</text><text class="terminal-1660145454-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-1660145454-line-15)">&#160;(v5.11.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1660145454-r6" x="1500.6" y="386" textLength="12.2" clip-path="url(#terminal-1660145454-line-15)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="386" textLength="12.2" clip-path="url(#terminal-1660145454-line-15)">
+</text><text class="terminal-1660145454-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-16)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="410.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-16)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-16)">
+</text><text class="terminal-1660145454-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-17)">│</text><text class="terminal-1660145454-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">-f</text><text class="terminal-1660145454-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-17)">-</text><text class="terminal-1660145454-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">-f</text><text class="terminal-1660145454-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-1660145454-line-17)">inal_cmd</text><text class="terminal-1660145454-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-1660145454-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-1660145454-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-1660145454-line-17)">smol</text><text class="terminal-1660145454-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">-k</text><text class="terminal-1660145454-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">8s</text><text class="terminal-1660145454-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">-l</text><text class="terminal-1660145454-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">ab</text><text class="terminal-1660145454-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-1660145454-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-1660145454-r6" x="1500.6" y="434.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-17)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="434.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-17)">
+</text><text class="terminal-1660145454-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-18)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="459.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-18)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="459.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-18)">
+</text><text class="terminal-1660145454-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-19)">│</text><text class="terminal-1660145454-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-19)">-h</text><text class="terminal-1660145454-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-19)">-</text><text class="terminal-1660145454-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-19)">-h</text><text class="terminal-1660145454-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-1660145454-line-19)">elp</text><text class="terminal-1660145454-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-1660145454-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1660145454-r6" x="1500.6" y="483.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-19)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="483.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-19)">
+</text><text class="terminal-1660145454-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-1660145454-line-20)">╰─</text><text class="terminal-1660145454-r6" x="24.4" y="508" textLength="841.8" clip-path="url(#terminal-1660145454-line-20)">─────────────────────────────────────────────────────────────────────</text><text class="terminal-1660145454-r6" x="866.2" y="508" textLength="109.8" clip-path="url(#terminal-1660145454-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-1660145454-r6" x="976" y="508" textLength="500.2" clip-path="url(#terminal-1660145454-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-1660145454-r6" x="1488.4" y="508" textLength="24.4" clip-path="url(#terminal-1660145454-line-20)">─╯</text><text class="terminal-1660145454-r1" x="1512.8" y="508" textLength="12.2" clip-path="url(#terminal-1660145454-line-20)">
 </text>
     </g>
     </g>

--- a/docs/k8s_apps/prometheus.md
+++ b/docs/k8s_apps/prometheus.md
@@ -78,7 +78,7 @@ apps:
       # path in the argo repo to point to. Trailing slash very important! This
       # is an app of apps. Change to "monitoring/kube-prometheus-stack/" to
       # only install kube-prometheus-stack (foregoing loki and push gateway)
-      path: prometheus/
+      path: prometheus/app_of_apps/
       # either the branch or tag to point at in the argo repo above
       revision: main
       # kubernetes cluster to install the k8s app into, defaults to Argo CD default

--- a/docs/k8s_apps/prometheus.md
+++ b/docs/k8s_apps/prometheus.md
@@ -56,12 +56,17 @@ apps:
 ```yaml
 apps:
   prometheus:
+  prometheus:
     description: |
-      Full monitoring stack with [link=https://prometheus.io/docs/introduction/overview/]Prometheus[/link], grafana, loki, and alert manager.
+      Full monitoring stack with [link=https://prometheus.io/docs/introduction/overview/]Prometheus[/link], [link=https://grafana.com/oss/loki/]Loki[/link], [link=https://prometheus.io/docs/alerting/latest/alertmanager/]Alert Manager[/link], and [link=https://grafana.com/oss/grafana/]Grafana[/link].
 
-      smol-k8s-lab supports initialization by setting up your ingress hostnames.
+      smol-k8s-lab supports initialization by setting up your ingress hostnames. It will also setup Oauth2 for Grafana directly by creating an app in Zitadel for you.
 
+      For Prometheus and Alert Manager, we use vouch-proxy via Ingress resource annotations to forward users to Zitadel for auth, so the frontend is not insecure.
     enabled: false
+    init:
+      # if init is enabled, we'll set up an app in Zitadel for using Oauth2 with Grafana
+      enabled: true
     argo:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1264,61 +1264,61 @@ requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
 
 [[package]]
 name = "grpcio"
-version = "1.64.1"
+version = "1.65.0"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "grpcio-1.64.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:55697ecec192bc3f2f3cc13a295ab670f51de29884ca9ae6cd6247df55df2502"},
-    {file = "grpcio-1.64.1-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:3b64ae304c175671efdaa7ec9ae2cc36996b681eb63ca39c464958396697daff"},
-    {file = "grpcio-1.64.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:bac71b4b28bc9af61efcdc7630b166440bbfbaa80940c9a697271b5e1dabbc61"},
-    {file = "grpcio-1.64.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6c024ffc22d6dc59000faf8ad781696d81e8e38f4078cb0f2630b4a3cf231a90"},
-    {file = "grpcio-1.64.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7cd5c1325f6808b8ae31657d281aadb2a51ac11ab081ae335f4f7fc44c1721d"},
-    {file = "grpcio-1.64.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0a2813093ddb27418a4c99f9b1c223fab0b053157176a64cc9db0f4557b69bd9"},
-    {file = "grpcio-1.64.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2981c7365a9353f9b5c864595c510c983251b1ab403e05b1ccc70a3d9541a73b"},
-    {file = "grpcio-1.64.1-cp310-cp310-win32.whl", hash = "sha256:1262402af5a511c245c3ae918167eca57342c72320dffae5d9b51840c4b2f86d"},
-    {file = "grpcio-1.64.1-cp310-cp310-win_amd64.whl", hash = "sha256:19264fc964576ddb065368cae953f8d0514ecc6cb3da8903766d9fb9d4554c33"},
-    {file = "grpcio-1.64.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:58b1041e7c870bb30ee41d3090cbd6f0851f30ae4eb68228955d973d3efa2e61"},
-    {file = "grpcio-1.64.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bbc5b1d78a7822b0a84c6f8917faa986c1a744e65d762ef6d8be9d75677af2ca"},
-    {file = "grpcio-1.64.1-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:5841dd1f284bd1b3d8a6eca3a7f062b06f1eec09b184397e1d1d43447e89a7ae"},
-    {file = "grpcio-1.64.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8caee47e970b92b3dd948371230fcceb80d3f2277b3bf7fbd7c0564e7d39068e"},
-    {file = "grpcio-1.64.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73819689c169417a4f978e562d24f2def2be75739c4bed1992435d007819da1b"},
-    {file = "grpcio-1.64.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:6503b64c8b2dfad299749cad1b595c650c91e5b2c8a1b775380fcf8d2cbba1e9"},
-    {file = "grpcio-1.64.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1de403fc1305fd96cfa75e83be3dee8538f2413a6b1685b8452301c7ba33c294"},
-    {file = "grpcio-1.64.1-cp311-cp311-win32.whl", hash = "sha256:d4d29cc612e1332237877dfa7fe687157973aab1d63bd0f84cf06692f04c0367"},
-    {file = "grpcio-1.64.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e56462b05a6f860b72f0fa50dca06d5b26543a4e88d0396259a07dc30f4e5aa"},
-    {file = "grpcio-1.64.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:4657d24c8063e6095f850b68f2d1ba3b39f2b287a38242dcabc166453e950c59"},
-    {file = "grpcio-1.64.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:62b4e6eb7bf901719fce0ca83e3ed474ae5022bb3827b0a501e056458c51c0a1"},
-    {file = "grpcio-1.64.1-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:ee73a2f5ca4ba44fa33b4d7d2c71e2c8a9e9f78d53f6507ad68e7d2ad5f64a22"},
-    {file = "grpcio-1.64.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:198908f9b22e2672a998870355e226a725aeab327ac4e6ff3a1399792ece4762"},
-    {file = "grpcio-1.64.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39b9d0acaa8d835a6566c640f48b50054f422d03e77e49716d4c4e8e279665a1"},
-    {file = "grpcio-1.64.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:5e42634a989c3aa6049f132266faf6b949ec2a6f7d302dbb5c15395b77d757eb"},
-    {file = "grpcio-1.64.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b1a82e0b9b3022799c336e1fc0f6210adc019ae84efb7321d668129d28ee1efb"},
-    {file = "grpcio-1.64.1-cp312-cp312-win32.whl", hash = "sha256:55260032b95c49bee69a423c2f5365baa9369d2f7d233e933564d8a47b893027"},
-    {file = "grpcio-1.64.1-cp312-cp312-win_amd64.whl", hash = "sha256:c1a786ac592b47573a5bb7e35665c08064a5d77ab88a076eec11f8ae86b3e3f6"},
-    {file = "grpcio-1.64.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:a011ac6c03cfe162ff2b727bcb530567826cec85eb8d4ad2bfb4bd023287a52d"},
-    {file = "grpcio-1.64.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:4d6dab6124225496010bd22690f2d9bd35c7cbb267b3f14e7a3eb05c911325d4"},
-    {file = "grpcio-1.64.1-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:a5e771d0252e871ce194d0fdcafd13971f1aae0ddacc5f25615030d5df55c3a2"},
-    {file = "grpcio-1.64.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2c3c1b90ab93fed424e454e93c0ed0b9d552bdf1b0929712b094f5ecfe7a23ad"},
-    {file = "grpcio-1.64.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20405cb8b13fd779135df23fabadc53b86522d0f1cba8cca0e87968587f50650"},
-    {file = "grpcio-1.64.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0cc79c982ccb2feec8aad0e8fb0d168bcbca85bc77b080d0d3c5f2f15c24ea8f"},
-    {file = "grpcio-1.64.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a3a035c37ce7565b8f4f35ff683a4db34d24e53dc487e47438e434eb3f701b2a"},
-    {file = "grpcio-1.64.1-cp38-cp38-win32.whl", hash = "sha256:1257b76748612aca0f89beec7fa0615727fd6f2a1ad580a9638816a4b2eb18fd"},
-    {file = "grpcio-1.64.1-cp38-cp38-win_amd64.whl", hash = "sha256:0a12ddb1678ebc6a84ec6b0487feac020ee2b1659cbe69b80f06dbffdb249122"},
-    {file = "grpcio-1.64.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:75dbbf415026d2862192fe1b28d71f209e2fd87079d98470db90bebe57b33179"},
-    {file = "grpcio-1.64.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e3d9f8d1221baa0ced7ec7322a981e28deb23749c76eeeb3d33e18b72935ab62"},
-    {file = "grpcio-1.64.1-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:5f8b75f64d5d324c565b263c67dbe4f0af595635bbdd93bb1a88189fc62ed2e5"},
-    {file = "grpcio-1.64.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c84ad903d0d94311a2b7eea608da163dace97c5fe9412ea311e72c3684925602"},
-    {file = "grpcio-1.64.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:940e3ec884520155f68a3b712d045e077d61c520a195d1a5932c531f11883489"},
-    {file = "grpcio-1.64.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f10193c69fc9d3d726e83bbf0f3d316f1847c3071c8c93d8090cf5f326b14309"},
-    {file = "grpcio-1.64.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ac15b6c2c80a4d1338b04d42a02d376a53395ddf0ec9ab157cbaf44191f3ffdd"},
-    {file = "grpcio-1.64.1-cp39-cp39-win32.whl", hash = "sha256:03b43d0ccf99c557ec671c7dede64f023c7da9bb632ac65dbc57f166e4970040"},
-    {file = "grpcio-1.64.1-cp39-cp39-win_amd64.whl", hash = "sha256:ed6091fa0adcc7e4ff944090cf203a52da35c37a130efa564ded02b7aff63bcd"},
-    {file = "grpcio-1.64.1.tar.gz", hash = "sha256:8d51dd1c59d5fa0f34266b80a3805ec29a1f26425c2a54736133f6d87fc4968a"},
+    {file = "grpcio-1.65.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:66ea0ca6108fcb391444bb7b37d04eac85bfaea1cfaf16db675d3734fc74ca1b"},
+    {file = "grpcio-1.65.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:45d371dc4436fdcc31677f75b3ebe6175fbf0712ced49e0e4dfc18bbaf50f5a7"},
+    {file = "grpcio-1.65.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:02dbbe113ec48581da07b7ddf52bfd49f5772374c4b5e36ea25131ce00b4f4f3"},
+    {file = "grpcio-1.65.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5c9ee7b8f1ac82cc24f223cd7ec803c17079f90e63022d3e66c5e53fff0afb99"},
+    {file = "grpcio-1.65.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da927f8a44e42837ae0027a3a063c85e2b26491d2babd4554e116f66fd46045d"},
+    {file = "grpcio-1.65.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:9916ea670a589f95f2453a4a5040294ace096271c126e684a1e45e61af76c988"},
+    {file = "grpcio-1.65.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c46114787c5f530e845d2781f914600aade04b4f132dd012efb31bc4f76a72bb"},
+    {file = "grpcio-1.65.0-cp310-cp310-win32.whl", hash = "sha256:1362d94ac9c05b202736180d23296840e00f495859b206261e6ed03a6d41978b"},
+    {file = "grpcio-1.65.0-cp310-cp310-win_amd64.whl", hash = "sha256:00ed0828980009ce852d98230cdd2d5a22a4bcb946b5a0f6334dfd8258374cd7"},
+    {file = "grpcio-1.65.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:25303f3747522252dd9cfcbacb88d828a36040f513e28fba17ee6184ebc3d330"},
+    {file = "grpcio-1.65.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2a2b368717dd8e0f6cb7e412d3b3bfb0012f61c04b2f76dbed669b0f5cf3fb0c"},
+    {file = "grpcio-1.65.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:93c41fb74c576dc0130b190a5775197282115c6abbe1d913d42d9a2f9d98fdae"},
+    {file = "grpcio-1.65.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34eb4fb9ef4d11ea741d264916d1b31a9e169d539a6f1c8300e04c493eec747e"},
+    {file = "grpcio-1.65.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55c41272f9d7d3503e3e3e93f3f98589f07075eebd24e1c291a1df2e8ef40a49"},
+    {file = "grpcio-1.65.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c275bac926754022c89ef03f16470f65b811e2cc25f2167d365564ad43e31001"},
+    {file = "grpcio-1.65.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b02db2a59071f4d05cfc4d0c972759778d27e1d3347f22ca178b91117ad10541"},
+    {file = "grpcio-1.65.0-cp311-cp311-win32.whl", hash = "sha256:ec9f41b9b0eb6407a6edb21bc22cb32e03cae76cde9c1d8bb151ed77c2c5af94"},
+    {file = "grpcio-1.65.0-cp311-cp311-win_amd64.whl", hash = "sha256:3efc8b0600870f5e518dd2738188b3ba7b1bb2668244c9a2a8c4debda4ffe62b"},
+    {file = "grpcio-1.65.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:d787abafafa9ed71e17220d4178c883abdb380e0484bd8965cb2e06375c7495b"},
+    {file = "grpcio-1.65.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:52347f21d6ec77d7e7e4d5037f5e8ac0a0c851856d9459f9f95b009c2c740b4a"},
+    {file = "grpcio-1.65.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:b16e1cd9b9cb9ac942cb20b7a2b1c5d35b9e61017e2998bf242a6f7748071795"},
+    {file = "grpcio-1.65.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89bc9c8c6743a48f115fea8f3fada76be269d1914bf636e5fdb7cec9cdf192bc"},
+    {file = "grpcio-1.65.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5a2ae900e6423438c4a9a5be38e9228621340a18333371215c0419d24a254ef"},
+    {file = "grpcio-1.65.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:4f451091ddd28f00c655f0b1e208cca705d40e4fde56a3cf849fead61a700d10"},
+    {file = "grpcio-1.65.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4e30cd885e02abb98d6b0d5beb6259a567b0ce1416c498ec815fe383adb77864"},
+    {file = "grpcio-1.65.0-cp312-cp312-win32.whl", hash = "sha256:9a9a0ce10a07923ebd48c056060052ebddfbec3193cdd32207af358ef317b00a"},
+    {file = "grpcio-1.65.0-cp312-cp312-win_amd64.whl", hash = "sha256:87d9350ffe1a84b7441db7c70fdb4e51269a379f7a95d696d0d133831c4f9a19"},
+    {file = "grpcio-1.65.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:0c504b30fc2fba143d9254e0240243b5866df9b7523162448797f4b21b5f30d5"},
+    {file = "grpcio-1.65.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:480be4d41ceb5a7f22ecfc8db1ab68aeb58cc1a2da0865a91917d3cd0438dac7"},
+    {file = "grpcio-1.65.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:984a1627b50d5df4a24120302ca95adb5139ba1c40354ba258fc2913666d8ee7"},
+    {file = "grpcio-1.65.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f242956c0f4985dfcc920cd251cd7a899ca168e157e98c9b74a688657e813ad6"},
+    {file = "grpcio-1.65.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ea93f570b2341c69635b8a333afb99fb4d5584f26a9cc94f06e56c943648aab"},
+    {file = "grpcio-1.65.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1bebefd76517a43d0e77a5dcd61a8b69e9775340d856a0b35c6368ae628f7714"},
+    {file = "grpcio-1.65.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:356d10a491a92a08c21aef806379f7b020f591c23580e3d29aeeb59d45908c86"},
+    {file = "grpcio-1.65.0-cp38-cp38-win32.whl", hash = "sha256:c3294fd3ef9faa1fe14ad15d72dd7d2ee9fee6d3bd29a08c53e59a3c94de9cc9"},
+    {file = "grpcio-1.65.0-cp38-cp38-win_amd64.whl", hash = "sha256:a2defc49c984550f25034e88d17a7e69dba6deb2b981d8f56f19b3aaa788ff30"},
+    {file = "grpcio-1.65.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:b73022222ed4bf718d3d8527a9b88b162074a62c7530d30f4e951b56304b0f19"},
+    {file = "grpcio-1.65.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:16e0f789158ecc8309e0a2f16cb8c5e4753f351a7673aab75f42783c83f1e38b"},
+    {file = "grpcio-1.65.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:cb0bd8bfba21fe0318317bf11687c67a3f8ce726369c0b3ccf4e6607fc5bc5f2"},
+    {file = "grpcio-1.65.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1096f0fa79ec601aefd71685d3a610cdde96274c38cd8adcef972660297669a"},
+    {file = "grpcio-1.65.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e576a88ce82fea70e68c548aceb5cd560c27da50091581996858bbbe01230c83"},
+    {file = "grpcio-1.65.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ab70bd1ccb05ef373b691a9b9985289d8b2cf63c704471f5ee132e228d351af5"},
+    {file = "grpcio-1.65.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:03eab632a8ce8dba00d97482d2821bf752a7c3cb4dc051be6c587ad3ca1c3e6d"},
+    {file = "grpcio-1.65.0-cp39-cp39-win32.whl", hash = "sha256:f19bb85795ca82e007be427e7b6ac5e730023ffbab69d39ddeb1b84c6339df16"},
+    {file = "grpcio-1.65.0-cp39-cp39-win_amd64.whl", hash = "sha256:dbd7eeafa67d8e403ac61caa31ebda2861435dcfd7bb7953c4ef05ad2ecf74bf"},
+    {file = "grpcio-1.65.0.tar.gz", hash = "sha256:2c7891f66daefc80cce1bed6bc0c2802d26dac46544ba1be79c4e7d85661dd73"},
 ]
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.64.1)"]
+protobuf = ["grpcio-tools (>=1.65.0)"]
 
 [[package]]
 name = "gruut"
@@ -4275,13 +4275,13 @@ test = ["Cython", "array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "me
 
 [[package]]
 name = "setuptools"
-version = "70.2.0"
+version = "70.3.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05"},
-    {file = "setuptools-70.2.0.tar.gz", hash = "sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1"},
+    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
+    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
 ]
 
 [package.extras]
@@ -4685,13 +4685,13 @@ files = [
 
 [[package]]
 name = "textual"
-version = "0.71.0"
+version = "0.72.0"
 description = "Modern Text User Interface framework"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "textual-0.71.0-py3-none-any.whl", hash = "sha256:60500cc63ffd98a4aff8679976a1530d5e99a881e13bb040d26558a2c45f49d8"},
-    {file = "textual-0.71.0.tar.gz", hash = "sha256:a38a3bd7e450ed173b59ab1c93a3aa8174d95bc5c79647f220a50243236ce70a"},
+    {file = "textual-0.72.0-py3-none-any.whl", hash = "sha256:a9886eb96bd6391b8795244d2b8fe592204556c42264ea7513a1211584e17366"},
+    {file = "textual-0.72.0.tar.gz", hash = "sha256:14174ce8d49016a85aa6c0669d0881b5419e98cf46d429f263314295409ed262"},
 ]
 
 [package.dependencies]
@@ -5563,4 +5563,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "6d4083063344915ca55c4e5dcfc3968b9a8802ffb5848dff85b77c7470379a24"
+content-hash = "de4c8131a4a774b38782c6c9793fe6a5a051fb18c58ef3a7d408564e02f912a8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "5.10.0"
+version       = "5.11.0"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]
@@ -43,7 +43,7 @@ requests           = "^2.32"
 rich               = "^13.0"
 ruamel-yaml        = "^0.18"
 ruamel-yaml-string = "^0.1"
-textual            = "^0.71"
+textual            = "^0.72"
 xdg-base-dirs      = "^6.0"
 pygame             = "^2.5"
 python-ulid        = "^2.6"

--- a/smol_k8s_lab/__init__.py
+++ b/smol_k8s_lab/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.11
+#!/usr/bin/env python4.11
 """
            NAME: smol-k8s-lab
     DESCRIPTION: package, cli, and tui for setting up k8s on metal with
@@ -255,17 +255,16 @@ def main(config: str = "",
         else:
             api_tls_verify = True
 
-        prometheus_stack = apps.pop('prometheus_crds', {'enabled': False})
         # Setup minio, our local s3 provider, is essential for creating buckets
         # and cnpg operator, our postgresql operator for creating postgres clusters
         setup_operators(argocd,
-                        prometheus_stack,
-                        apps.pop('longhorn', {}),
-                        apps.pop('k8up', {}),
-                        apps.pop('minio_operator', {}),
-                        apps.pop('seaweedfs', {}),
-                        apps.pop('cnpg_operator', {}),
-                        apps.pop('postgres_operator', {}),
+                        apps.pop('prometheus_crds', {'enabled': False}),
+                        apps.pop('longhorn', {'enabled': False}),
+                        apps.pop('k8up', {'enabled': False}),
+                        apps.pop('minio_operator', {'enabled': False}),
+                        apps.pop('seaweedfs', {'enabled': False}),
+                        apps.pop('cnpg_operator', {'enabled': False}),
+                        apps.pop('postgres_operator', {'enabled': False}),
                         bw)
 
         # global pvc storage class
@@ -298,9 +297,11 @@ def main(config: str = "",
                                oidc_obj)
 
         # this is currently just to make sure that grafana zitadel auth gets set up
+        prometheus_stack = apps.pop('prometheus', {'enabled': False})
         if prometheus_stack['enabled']:
             configure_prometheus_stack(argocd, prometheus_stack, oidc_obj, bw)
 
+        # setup nextcloud, home assistant, mastodon, and matrix
         setup_federated_apps(
                 argocd,
                 api_tls_verify,

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -1413,7 +1413,7 @@ apps:
       # path in the argo repo to point to. Trailing slash very important! This
       # is an app of apps. Change to "monitoring/kube-prometheus-stack/" to
       # only install kube-prometheus-stack (foregoing loki and push gateway)
-      path: prometheus/
+      path: prometheus/app_of_apps/
       # either the branch or tag to point at in the argo repo above
       revision: main
       # kubernetes cluster to install the k8s app into, defaults to Argo CD default

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -1303,7 +1303,7 @@ apps:
       postgres-operator is a Kubernetes operator for postgresql by Zalando.
 
       smol-k8s-lab supports initialization by setting up your ingress hostnames, and then also creating a local s3 endpoint exclusively for backups with and additional configurable endpoint for backups to an external s3
-    enabled: true
+    enabled: false
     init:
       enabled: true
     backups:
@@ -1392,11 +1392,15 @@ apps:
 
   prometheus:
     description: |
-      Full monitoring stack with [link=https://prometheus.io/docs/introduction/overview/]Prometheus[/link], grafana, loki, and alert manager.
+      Full monitoring stack with [link=https://prometheus.io/docs/introduction/overview/]Prometheus[/link], [link=https://grafana.com/oss/loki/]Loki[/link], [link=https://prometheus.io/docs/alerting/latest/alertmanager/]Alert Manager[/link], and [link=https://grafana.com/oss/grafana/]Grafana[/link].
 
-      smol-k8s-lab supports initialization by setting up your ingress hostnames.
+      smol-k8s-lab supports initialization by setting up your ingress hostnames. It will also setup Oauth2 for Grafana directly by creating an app in Zitadel for you.
 
+      For Prometheus and Alert Manager, we use vouch-proxy via Ingress resource annotations to forward users to Zitadel for auth, so the frontend is not insecure.
     enabled: false
+    init:
+      # if init is enabled, we'll set up an app in Zitadel for using Oauth2 with Grafana
+      enabled: true
     argo:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:

--- a/smol_k8s_lab/k8s_apps/__init__.py
+++ b/smol_k8s_lab/k8s_apps/__init__.py
@@ -74,7 +74,10 @@ def setup_oidc_provider(argocd: ArgoCD,
                         argocd_fqdn: str = "") -> Zitadel | None:
     """
     sets up oidc provider. only zitadel is supported right now
-    if we choose to add keycloak back, we'll be adding the following arg
+
+    Returns Zitadel object for configuring other Zitadel authed services
+
+    IF we choose to add keycloak back, we'll be adding the following arg
     keycloak_dict: dict = {}
     """
     header("Setting up [green]OIDC[/]/[green]Oauth[/] Applications")

--- a/smol_k8s_lab/k8s_apps/monitoring/prometheus_stack.py
+++ b/smol_k8s_lab/k8s_apps/monitoring/prometheus_stack.py
@@ -1,0 +1,151 @@
+# external libraries
+import logging as log
+
+# internal libraries
+from smol_k8s_lab.k8s_tools.argocd_util import ArgoCD
+from smol_k8s_lab.bitwarden.bw_cli import BwCLI
+from smol_k8s_lab.k8s_apps.identity_provider.zitadel_api import Zitadel
+from smol_k8s_lab.utils.rich_cli.console_logging import sub_header, header
+
+def configure_prometheus_stack(argocd: ArgoCD,
+                               cfg: dict,
+                               zitadel: Zitadel,
+                               bitwarden: BwCLI = None) -> bool:
+    """
+    creates a prometheus stack app and initializes it with secrets if you'd like :)
+
+    required:
+        argocd            - ArgoCD() object for Argo CD operations
+        cfg               - dict, with at least argocd key and init key
+
+    optional:
+        zitadel     - Zitadel() object with session token to create zitadel oidc app and roles
+        bitwarden   - BwCLI() object with session token to create bitwarden items
+    """
+    # verify immediately if prometheus is installed
+    app_installed = argocd.check_if_app_exists('prometheus')
+
+    # verify if initialization is enabled
+    init = cfg.get('init', {'enabled': True, 'restore': {'enabled': False}})
+    init_enabled = init.get('enabled', True)
+
+    if app_installed:
+        header_start = "Syncing"
+    else:
+        header_start = "Setting up"
+
+    header(f"{header_start} [green]prometheus[/], so you can monitor your infrastructure",
+           '🔥')
+
+    secrets = cfg['argo']['secret_keys']
+    if secrets:
+        grafana_hostname = secrets['grafana_hostname']
+
+    # always declare prometheus namespace immediately
+    prometheus_namespace = cfg['argo']['namespace']
+
+    # initial secrets to deploy this app from scratch
+    if init_enabled and not app_installed:
+        argocd.k8s.create_namespace(prometheus_namespace)
+
+        # create prometheus OIDC Application
+        if zitadel:
+            log.debug("Creating an OIDC application in Zitadel...")
+            zitadel_hostname = zitadel.hostname
+            logout_uris = [f"https://{grafana_hostname}"]
+            redirect_uris = f"https://{grafana_hostname}/login/generic_oauth"
+            oidc_creds = zitadel.create_application("grafana",
+                                                    redirect_uris,
+                                                    logout_uris)
+            zitadel.create_role("grafana_users", "grafana Users", "grafana_users")
+            zitadel.update_user_grant(['grafana_users'])
+        else:
+            zitadel_hostname = ""
+
+        # if the user has bitwarden enabled
+        if bitwarden:
+            setup_bitwarden_items(argocd,
+                                  grafana_hostname,
+                                  prometheus_namespace,
+                                  zitadel_hostname,
+                                  oidc_creds,
+                                  bitwarden)
+
+        # else create these as Kubernetes secrets
+        else:
+            if zitadel:
+                # oidc secret
+                argocd.k8s.create_secret(
+                        'grafana-oidc-credentials',
+                        'grafana',
+                        {'user': oidc_creds['client_id'],
+                         'password': oidc_creds['client_secret']}
+                        )
+
+    if not app_installed:
+        argocd.install_app('prometheus', cfg['argo'])
+    else:
+        if bitwarden and init_enabled:
+            log.info("prometheus already installed 🎉")
+            refresh_bweso(argocd, grafana_hostname, bitwarden)
+
+
+def refresh_bweso(argocd: ArgoCD, grafana_hostname: str, bitwarden: BwCLI):
+    """
+    refresh the bitwarden item IDs for use with argocd-appset-secret-plugin
+    """
+    # update the prometheus values for the argocd appset
+    log.debug("making sure prometheus and grafana bitwarden IDs are present in "
+              "appset secret plugin")
+
+    oidc_id = bitwarden.get_item(
+            f"grafana-oidc-credentials-{grafana_hostname}", False
+            )[0]['id']
+
+    argocd.update_appset_secret(
+            {'grafana_oidc_credentials_bitwarden_id': oidc_id})
+
+
+def setup_bitwarden_items(argocd: ArgoCD,
+                          grafana_hostname: str,
+                          prometheus_namespace: str,
+                          zitadel_hostname: str,
+                          oidc_creds: str,
+                          bitwarden: BwCLI):
+    """
+    setup all the required secrets as items in bitwarden
+    """
+    sub_header("Creating prometheus related secrets in Bitwarden")
+
+    # OIDC credentials
+    log.info("Creating OIDC credentials for grafana in Bitwarden")
+    if zitadel_hostname:
+        if oidc_creds:
+            # for the credentials to zitadel
+            oidc_id = bitwarden.create_login(
+                    name='grafana-oidc-credentials',
+                    item_url=grafana_hostname,
+                    user=oidc_creds['client_id'],
+                    password=oidc_creds['client_secret']
+                    )
+        else:
+            # we assume the credentials already exist if they fail to create
+            oidc_id = bitwarden.get_item(
+                    f"grafana-oidc-credentials-{grafana_hostname}"
+                    )[0]['id']
+
+    # update the grafana values for the argocd appset
+    argocd.update_appset_secret(
+            {'grafana_oidc_credentials_bitwarden_id': oidc_id}
+            )
+
+    # reload the bitwarden ESO provider
+    try:
+        argocd.k8s.reload_deployment('bitwarden-eso-provider',
+                                     'external-secrets')
+    except Exception as e:
+        log.error(
+                "Couldn't scale down the [magenta]bitwarden-eso-provider[/]"
+                "deployment in [green]external-secrets[/] namespace. Recieved: "
+                f"{e}"
+                )

--- a/smol_k8s_lab/k8s_apps/monitoring/prometheus_stack.py
+++ b/smol_k8s_lab/k8s_apps/monitoring/prometheus_stack.py
@@ -103,7 +103,7 @@ def refresh_bweso(argocd: ArgoCD, grafana_hostname: str, bitwarden: BwCLI):
             )[0]['id']
 
     argocd.update_appset_secret(
-            {'grafana_oidc_credentials_bitwarden_id': oidc_id})
+            {'prometheus_grafana_oidc_credentials_bitwarden_id': oidc_id})
 
 
 def setup_bitwarden_items(argocd: ArgoCD,
@@ -136,7 +136,7 @@ def setup_bitwarden_items(argocd: ArgoCD,
 
     # update the grafana values for the argocd appset
     argocd.update_appset_secret(
-            {'grafana_oidc_credentials_bitwarden_id': oidc_id}
+            {'prometheus_grafana_oidc_credentials_bitwarden_id': oidc_id}
             )
 
     # reload the bitwarden ESO provider


### PR DESCRIPTION
This PR makes it so that anytime you install the Prometheus app, we'll automatically setup a Zitadel app for you to use for Oauth2, to keep your SSO working directly through apps that support it, which right now is just Grafana. Previously, we were using the vouch app to redirect to to zitadel. This PR removes the "man in the middle".

- Relates to https://github.com/small-hack/argocd-apps/pull/1073
- Closes #283
- changes `apps.prometheus.argo.path` to `promethus/app_of_apps/`
- adds `apps.prometheus.init.enabled` to enable initializing your self-hosted Zitadel Oauth2 app for use with Grafana