### PR TITLE
Add SMTP credentials for Zitadel; Removing hookshot from matrix bridges

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1531 562.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1214 562.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,131 +19,131 @@
         font-weight: 700;
     }
 
-    .terminal-1660145454-matrix {
+    .terminal-4228723192-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1660145454-title {
+    .terminal-4228723192-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1660145454-r1 { fill: #c5c8c6 }
-.terminal-1660145454-r2 { fill: #5f87ff }
-.terminal-1660145454-r3 { fill: #5f87af;font-style: italic; }
-.terminal-1660145454-r4 { fill: #5f87af }
-.terminal-1660145454-r5 { fill: #8787ff }
-.terminal-1660145454-r6 { fill: #afafff }
-.terminal-1660145454-r7 { fill: #87afff }
-.terminal-1660145454-r8 { fill: #afafff;font-weight: bold }
-.terminal-1660145454-r9 { fill: #868887 }
-.terminal-1660145454-r10 { fill: #6179a9 }
-.terminal-1660145454-r11 { fill: #6161a9 }
-.terminal-1660145454-r12 { fill: #7979a9;font-weight: bold }
-.terminal-1660145454-r13 { fill: #4961a9 }
+    .terminal-4228723192-r1 { fill: #c5c8c6 }
+.terminal-4228723192-r2 { fill: #5f87ff }
+.terminal-4228723192-r3 { fill: #5f87af;font-style: italic; }
+.terminal-4228723192-r4 { fill: #5f87af }
+.terminal-4228723192-r5 { fill: #8787ff }
+.terminal-4228723192-r6 { fill: #afafff }
+.terminal-4228723192-r7 { fill: #87afff }
+.terminal-4228723192-r8 { fill: #afafff;font-weight: bold }
+.terminal-4228723192-r9 { fill: #868887 }
+.terminal-4228723192-r10 { fill: #6179a9 }
+.terminal-4228723192-r11 { fill: #6161a9 }
+.terminal-4228723192-r12 { fill: #7979a9;font-weight: bold }
+.terminal-4228723192-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-1660145454-clip-terminal">
-      <rect x="0" y="0" width="1511.8" height="511.4" />
+    <clipPath id="terminal-4228723192-clip-terminal">
+      <rect x="0" y="0" width="1194.6" height="511.4" />
     </clipPath>
-    <clipPath id="terminal-1660145454-line-0">
-    <rect x="0" y="1.5" width="1512.8" height="24.65"/>
+    <clipPath id="terminal-4228723192-line-0">
+    <rect x="0" y="1.5" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-1">
-    <rect x="0" y="25.9" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-1">
+    <rect x="0" y="25.9" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-2">
-    <rect x="0" y="50.3" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-2">
+    <rect x="0" y="50.3" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-3">
-    <rect x="0" y="74.7" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-3">
+    <rect x="0" y="74.7" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-4">
-    <rect x="0" y="99.1" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-4">
+    <rect x="0" y="99.1" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-5">
-    <rect x="0" y="123.5" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-5">
+    <rect x="0" y="123.5" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-6">
-    <rect x="0" y="147.9" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-6">
+    <rect x="0" y="147.9" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-7">
-    <rect x="0" y="172.3" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-7">
+    <rect x="0" y="172.3" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-8">
-    <rect x="0" y="196.7" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-8">
+    <rect x="0" y="196.7" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-9">
-    <rect x="0" y="221.1" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-9">
+    <rect x="0" y="221.1" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-10">
-    <rect x="0" y="245.5" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-10">
+    <rect x="0" y="245.5" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-11">
-    <rect x="0" y="269.9" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-11">
+    <rect x="0" y="269.9" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-12">
-    <rect x="0" y="294.3" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-12">
+    <rect x="0" y="294.3" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-13">
-    <rect x="0" y="318.7" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-13">
+    <rect x="0" y="318.7" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-14">
-    <rect x="0" y="343.1" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-14">
+    <rect x="0" y="343.1" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-15">
-    <rect x="0" y="367.5" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-15">
+    <rect x="0" y="367.5" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-16">
-    <rect x="0" y="391.9" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-16">
+    <rect x="0" y="391.9" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-17">
-    <rect x="0" y="416.3" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-17">
+    <rect x="0" y="416.3" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-18">
-    <rect x="0" y="440.7" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-18">
+    <rect x="0" y="440.7" width="1195.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1660145454-line-19">
-    <rect x="0" y="465.1" width="1512.8" height="24.65"/>
+<clipPath id="terminal-4228723192-line-19">
+    <rect x="0" y="465.1" width="1195.6" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1529" height="560.4" rx="8"/><text class="terminal-1660145454-title" fill="#c5c8c6" text-anchor="middle" x="764" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1212" height="560.4" rx="8"/><text class="terminal-4228723192-title" fill="#c5c8c6" text-anchor="middle" x="606" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1660145454-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4228723192-clip-terminal)">
     
-    <g class="terminal-1660145454-matrix">
-    <text class="terminal-1660145454-r1" x="353.8" y="20" textLength="329.4" clip-path="url(#terminal-1660145454-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-1660145454-r2" x="695.4" y="20" textLength="146.4" clip-path="url(#terminal-1660145454-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-1660145454-r1" x="1512.8" y="20" textLength="12.2" clip-path="url(#terminal-1660145454-line-0)">
-</text><text class="terminal-1660145454-r1" x="1512.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-1)">
-</text><text class="terminal-1660145454-r3" x="353.8" y="68.8" textLength="793" clip-path="url(#terminal-1660145454-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-1660145454-r1" x="1512.8" y="68.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-2)">
-</text><text class="terminal-1660145454-r1" x="1512.8" y="93.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-3)">
-</text><text class="terminal-1660145454-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-1660145454-line-4)">Usage:</text><text class="terminal-1660145454-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-1660145454-line-4)">smol</text><text class="terminal-1660145454-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-4)">-k</text><text class="terminal-1660145454-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-4)">8s</text><text class="terminal-1660145454-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-4)">-l</text><text class="terminal-1660145454-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-4)">ab</text><text class="terminal-1660145454-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1660145454-line-4)">[OPTIONS]</text><text class="terminal-1660145454-r1" x="1512.8" y="117.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-4)">
-</text><text class="terminal-1660145454-r1" x="1512.8" y="142" textLength="12.2" clip-path="url(#terminal-1660145454-line-5)">
-</text><text class="terminal-1660145454-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1660145454-line-6)">╭─</text><text class="terminal-1660145454-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-1660145454-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-1660145454-r6" x="219.6" y="166.4" textLength="1268.8" clip-path="url(#terminal-1660145454-line-6)">────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1660145454-r6" x="1488.4" y="166.4" textLength="24.4" clip-path="url(#terminal-1660145454-line-6)">─╮</text><text class="terminal-1660145454-r1" x="1512.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-6)">
-</text><text class="terminal-1660145454-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-7)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="190.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-7)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-7)">
-</text><text class="terminal-1660145454-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-8)">│</text><text class="terminal-1660145454-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-8)">-c</text><text class="terminal-1660145454-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-8)">-</text><text class="terminal-1660145454-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-8)">-c</text><text class="terminal-1660145454-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-1660145454-line-8)">onfig</text><text class="terminal-1660145454-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-1660145454-line-8)">&#160;CONFIG_FILE</text><text class="terminal-1660145454-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-1660145454-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1660145454-r6" x="1500.6" y="215.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-8)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-8)">
-</text><text class="terminal-1660145454-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-9)">│</text><text class="terminal-1660145454-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-1660145454-line-9)">Defaults&#160;to&#160;</text><text class="terminal-1660145454-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-1660145454-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-1660145454-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-1660145454-line-9)">smol</text><text class="terminal-1660145454-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-9)">-k</text><text class="terminal-1660145454-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-9)">8s</text><text class="terminal-1660145454-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-9)">-l</text><text class="terminal-1660145454-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-9)">ab</text><text class="terminal-1660145454-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-1660145454-line-9)">/config.yaml</text><text class="terminal-1660145454-r6" x="1500.6" y="239.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-9)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-9)">
-</text><text class="terminal-1660145454-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1660145454-line-10)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="264" textLength="12.2" clip-path="url(#terminal-1660145454-line-10)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="264" textLength="12.2" clip-path="url(#terminal-1660145454-line-10)">
-</text><text class="terminal-1660145454-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-11)">│</text><text class="terminal-1660145454-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-1660145454-line-11)">-D</text><text class="terminal-1660145454-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-11)">-</text><text class="terminal-1660145454-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-1660145454-line-11)">-d</text><text class="terminal-1660145454-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-1660145454-line-11)">elete</text><text class="terminal-1660145454-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-1660145454-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-1660145454-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-1660145454-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1660145454-r6" x="1500.6" y="288.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-11)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-11)">
-</text><text class="terminal-1660145454-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-12)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="312.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-12)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-12)">
-</text><text class="terminal-1660145454-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-13)">│</text><text class="terminal-1660145454-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">-i</text><text class="terminal-1660145454-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-13)">-</text><text class="terminal-1660145454-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">-i</text><text class="terminal-1660145454-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-1660145454-line-13)">nteractive</text><text class="terminal-1660145454-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-1660145454-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-1660145454-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-1660145454-line-13)">smol</text><text class="terminal-1660145454-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">-k</text><text class="terminal-1660145454-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">8s</text><text class="terminal-1660145454-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">-l</text><text class="terminal-1660145454-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-1660145454-line-13)">ab</text><text class="terminal-1660145454-r6" x="1500.6" y="337.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-13)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-13)">
-</text><text class="terminal-1660145454-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-14)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="361.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-14)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-14)">
-</text><text class="terminal-1660145454-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1660145454-line-15)">│</text><text class="terminal-1660145454-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">-v</text><text class="terminal-1660145454-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-1660145454-line-15)">-</text><text class="terminal-1660145454-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">-v</text><text class="terminal-1660145454-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-1660145454-line-15)">ersion</text><text class="terminal-1660145454-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-1660145454-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-1660145454-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-1660145454-line-15)">smol</text><text class="terminal-1660145454-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">-k</text><text class="terminal-1660145454-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">8s</text><text class="terminal-1660145454-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">-l</text><text class="terminal-1660145454-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-1660145454-line-15)">ab</text><text class="terminal-1660145454-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-1660145454-line-15)">&#160;(v5.11.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1660145454-r6" x="1500.6" y="386" textLength="12.2" clip-path="url(#terminal-1660145454-line-15)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="386" textLength="12.2" clip-path="url(#terminal-1660145454-line-15)">
-</text><text class="terminal-1660145454-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-16)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="410.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-16)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1660145454-line-16)">
-</text><text class="terminal-1660145454-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-17)">│</text><text class="terminal-1660145454-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">-f</text><text class="terminal-1660145454-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-17)">-</text><text class="terminal-1660145454-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">-f</text><text class="terminal-1660145454-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-1660145454-line-17)">inal_cmd</text><text class="terminal-1660145454-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-1660145454-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-1660145454-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-1660145454-line-17)">smol</text><text class="terminal-1660145454-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">-k</text><text class="terminal-1660145454-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">8s</text><text class="terminal-1660145454-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">-l</text><text class="terminal-1660145454-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1660145454-line-17)">ab</text><text class="terminal-1660145454-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-1660145454-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-1660145454-r6" x="1500.6" y="434.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-17)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="434.8" textLength="12.2" clip-path="url(#terminal-1660145454-line-17)">
-</text><text class="terminal-1660145454-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-18)">│</text><text class="terminal-1660145454-r6" x="1500.6" y="459.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-18)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="459.2" textLength="12.2" clip-path="url(#terminal-1660145454-line-18)">
-</text><text class="terminal-1660145454-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-19)">│</text><text class="terminal-1660145454-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-19)">-h</text><text class="terminal-1660145454-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-19)">-</text><text class="terminal-1660145454-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-1660145454-line-19)">-h</text><text class="terminal-1660145454-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-1660145454-line-19)">elp</text><text class="terminal-1660145454-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-1660145454-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1660145454-r6" x="1500.6" y="483.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-19)">│</text><text class="terminal-1660145454-r1" x="1512.8" y="483.6" textLength="12.2" clip-path="url(#terminal-1660145454-line-19)">
-</text><text class="terminal-1660145454-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-1660145454-line-20)">╰─</text><text class="terminal-1660145454-r6" x="24.4" y="508" textLength="841.8" clip-path="url(#terminal-1660145454-line-20)">─────────────────────────────────────────────────────────────────────</text><text class="terminal-1660145454-r6" x="866.2" y="508" textLength="109.8" clip-path="url(#terminal-1660145454-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-1660145454-r6" x="976" y="508" textLength="500.2" clip-path="url(#terminal-1660145454-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-1660145454-r6" x="1488.4" y="508" textLength="24.4" clip-path="url(#terminal-1660145454-line-20)">─╯</text><text class="terminal-1660145454-r1" x="1512.8" y="508" textLength="12.2" clip-path="url(#terminal-1660145454-line-20)">
+    <g class="terminal-4228723192-matrix">
+    <text class="terminal-4228723192-r1" x="195.2" y="20" textLength="329.4" clip-path="url(#terminal-4228723192-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-4228723192-r2" x="536.8" y="20" textLength="146.4" clip-path="url(#terminal-4228723192-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-4228723192-r1" x="1195.6" y="20" textLength="12.2" clip-path="url(#terminal-4228723192-line-0)">
+</text><text class="terminal-4228723192-r1" x="1195.6" y="44.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-1)">
+</text><text class="terminal-4228723192-r3" x="195.2" y="68.8" textLength="793" clip-path="url(#terminal-4228723192-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-4228723192-r1" x="1195.6" y="68.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-2)">
+</text><text class="terminal-4228723192-r1" x="1195.6" y="93.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-3)">
+</text><text class="terminal-4228723192-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-4228723192-line-4)">Usage:</text><text class="terminal-4228723192-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-4228723192-line-4)">smol</text><text class="terminal-4228723192-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-4)">-k</text><text class="terminal-4228723192-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-4)">8s</text><text class="terminal-4228723192-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-4)">-l</text><text class="terminal-4228723192-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-4)">ab</text><text class="terminal-4228723192-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-4228723192-line-4)">[OPTIONS]</text><text class="terminal-4228723192-r1" x="1195.6" y="117.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-4)">
+</text><text class="terminal-4228723192-r1" x="1195.6" y="142" textLength="12.2" clip-path="url(#terminal-4228723192-line-5)">
+</text><text class="terminal-4228723192-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-4228723192-line-6)">╭─</text><text class="terminal-4228723192-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-4228723192-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-4228723192-r6" x="219.6" y="166.4" textLength="951.6" clip-path="url(#terminal-4228723192-line-6)">──────────────────────────────────────────────────────────────────────────────</text><text class="terminal-4228723192-r6" x="1171.2" y="166.4" textLength="24.4" clip-path="url(#terminal-4228723192-line-6)">─╮</text><text class="terminal-4228723192-r1" x="1195.6" y="166.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-6)">
+</text><text class="terminal-4228723192-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-7)">│</text><text class="terminal-4228723192-r6" x="1183.4" y="190.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-7)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="190.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-7)">
+</text><text class="terminal-4228723192-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-8)">│</text><text class="terminal-4228723192-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-4228723192-line-8)">-c</text><text class="terminal-4228723192-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-8)">-</text><text class="terminal-4228723192-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-4228723192-line-8)">-c</text><text class="terminal-4228723192-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-4228723192-line-8)">onfig</text><text class="terminal-4228723192-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-4228723192-line-8)">&#160;CONFIG_FILE</text><text class="terminal-4228723192-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-4228723192-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4228723192-r6" x="1183.4" y="215.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-8)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="215.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-8)">
+</text><text class="terminal-4228723192-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-9)">│</text><text class="terminal-4228723192-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-4228723192-line-9)">Defaults&#160;to&#160;</text><text class="terminal-4228723192-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-4228723192-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-4228723192-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-4228723192-line-9)">smol</text><text class="terminal-4228723192-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-9)">-k</text><text class="terminal-4228723192-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-9)">8s</text><text class="terminal-4228723192-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-9)">-l</text><text class="terminal-4228723192-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-9)">ab</text><text class="terminal-4228723192-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-4228723192-line-9)">/config.yaml</text><text class="terminal-4228723192-r6" x="1183.4" y="239.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-9)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="239.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-9)">
+</text><text class="terminal-4228723192-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-4228723192-line-10)">│</text><text class="terminal-4228723192-r6" x="1183.4" y="264" textLength="12.2" clip-path="url(#terminal-4228723192-line-10)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="264" textLength="12.2" clip-path="url(#terminal-4228723192-line-10)">
+</text><text class="terminal-4228723192-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-11)">│</text><text class="terminal-4228723192-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-4228723192-line-11)">-D</text><text class="terminal-4228723192-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-11)">-</text><text class="terminal-4228723192-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-4228723192-line-11)">-d</text><text class="terminal-4228723192-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-4228723192-line-11)">elete</text><text class="terminal-4228723192-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-4228723192-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-4228723192-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-4228723192-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4228723192-r6" x="1183.4" y="288.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-11)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="288.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-11)">
+</text><text class="terminal-4228723192-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-12)">│</text><text class="terminal-4228723192-r6" x="1183.4" y="312.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-12)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="312.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-12)">
+</text><text class="terminal-4228723192-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-13)">│</text><text class="terminal-4228723192-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-4228723192-line-13)">-i</text><text class="terminal-4228723192-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-13)">-</text><text class="terminal-4228723192-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-4228723192-line-13)">-i</text><text class="terminal-4228723192-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-4228723192-line-13)">nteractive</text><text class="terminal-4228723192-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-4228723192-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-4228723192-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-4228723192-line-13)">smol</text><text class="terminal-4228723192-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-4228723192-line-13)">-k</text><text class="terminal-4228723192-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-4228723192-line-13)">8s</text><text class="terminal-4228723192-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-4228723192-line-13)">-l</text><text class="terminal-4228723192-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-4228723192-line-13)">ab</text><text class="terminal-4228723192-r6" x="1183.4" y="337.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-13)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="337.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-13)">
+</text><text class="terminal-4228723192-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-14)">│</text><text class="terminal-4228723192-r6" x="1183.4" y="361.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-14)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="361.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-14)">
+</text><text class="terminal-4228723192-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-4228723192-line-15)">│</text><text class="terminal-4228723192-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-4228723192-line-15)">-v</text><text class="terminal-4228723192-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-4228723192-line-15)">-</text><text class="terminal-4228723192-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-4228723192-line-15)">-v</text><text class="terminal-4228723192-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-4228723192-line-15)">ersion</text><text class="terminal-4228723192-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-4228723192-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-4228723192-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-4228723192-line-15)">smol</text><text class="terminal-4228723192-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-4228723192-line-15)">-k</text><text class="terminal-4228723192-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-4228723192-line-15)">8s</text><text class="terminal-4228723192-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-4228723192-line-15)">-l</text><text class="terminal-4228723192-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-4228723192-line-15)">ab</text><text class="terminal-4228723192-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-4228723192-line-15)">&#160;(v5.13.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4228723192-r6" x="1183.4" y="386" textLength="12.2" clip-path="url(#terminal-4228723192-line-15)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="386" textLength="12.2" clip-path="url(#terminal-4228723192-line-15)">
+</text><text class="terminal-4228723192-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-16)">│</text><text class="terminal-4228723192-r6" x="1183.4" y="410.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-16)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="410.4" textLength="12.2" clip-path="url(#terminal-4228723192-line-16)">
+</text><text class="terminal-4228723192-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-17)">│</text><text class="terminal-4228723192-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-4228723192-line-17)">-f</text><text class="terminal-4228723192-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-17)">-</text><text class="terminal-4228723192-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-4228723192-line-17)">-f</text><text class="terminal-4228723192-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-4228723192-line-17)">inal_cmd</text><text class="terminal-4228723192-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-4228723192-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-4228723192-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-4228723192-line-17)">smol</text><text class="terminal-4228723192-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-4228723192-line-17)">-k</text><text class="terminal-4228723192-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-4228723192-line-17)">8s</text><text class="terminal-4228723192-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-4228723192-line-17)">-l</text><text class="terminal-4228723192-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-4228723192-line-17)">ab</text><text class="terminal-4228723192-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-4228723192-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-4228723192-r6" x="1183.4" y="434.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-17)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="434.8" textLength="12.2" clip-path="url(#terminal-4228723192-line-17)">
+</text><text class="terminal-4228723192-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-18)">│</text><text class="terminal-4228723192-r6" x="1183.4" y="459.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-18)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="459.2" textLength="12.2" clip-path="url(#terminal-4228723192-line-18)">
+</text><text class="terminal-4228723192-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-19)">│</text><text class="terminal-4228723192-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-19)">-h</text><text class="terminal-4228723192-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-19)">-</text><text class="terminal-4228723192-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-4228723192-line-19)">-h</text><text class="terminal-4228723192-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-4228723192-line-19)">elp</text><text class="terminal-4228723192-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-4228723192-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4228723192-r6" x="1183.4" y="483.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-19)">│</text><text class="terminal-4228723192-r1" x="1195.6" y="483.6" textLength="12.2" clip-path="url(#terminal-4228723192-line-19)">
+</text><text class="terminal-4228723192-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-4228723192-line-20)">╰─</text><text class="terminal-4228723192-r6" x="24.4" y="508" textLength="524.6" clip-path="url(#terminal-4228723192-line-20)">───────────────────────────────────────────</text><text class="terminal-4228723192-r6" x="549" y="508" textLength="109.8" clip-path="url(#terminal-4228723192-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-4228723192-r6" x="658.8" y="508" textLength="500.2" clip-path="url(#terminal-4228723192-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-4228723192-r6" x="1171.2" y="508" textLength="24.4" clip-path="url(#terminal-4228723192-line-20)">─╯</text><text class="terminal-4228723192-r1" x="1195.6" y="508" textLength="12.2" clip-path="url(#terminal-4228723192-line-20)">
 </text>
     </g>
     </g>

--- a/docs/k8s_apps/zitadel.md
+++ b/docs/k8s_apps/zitadel.md
@@ -48,7 +48,7 @@ apps:
       # API via a service account to create the above described resources
       enabled: true
       values:
-        # mail server
+        # mail server, must include port! e.g. mymailserver.com:587
         smtp_host:
           value_from:
             env: ZITADEL_SMTP_HOST
@@ -205,7 +205,7 @@ apps:
         gender: GENDER_UNSPECIFIED
         # name of the default project to create OIDC applications in
         project: core
-        # mail server
+        # mail server, must include port! e.g. mymailserver.com:587
         smtp_host:
           value_from:
             env: ZITADEL_SMTP_HOST

--- a/docs/k8s_apps/zitadel.md
+++ b/docs/k8s_apps/zitadel.md
@@ -38,11 +38,28 @@ In addition to those one time init values, we also require a hostname to use for
 
 ## Sensitive values
 
-Sensitive values can be provided via environment variables using a `value_from` map on any value under `init.values` or `backups`. Example of providing s3 credentials and restic repo password via sensitive values:
+Sensitive values can be provided via environment variables using a `value_from` map on any value under `init.values` or `backups`. Example of both providing s3 credentials and restic repo password as well as smtp credentials via sensitive values:
 
 ```yaml
 apps:
   zitadel:
+    init:
+      # Switch to false if you don't want to create initial secrets or use the
+      # API via a service account to create the above described resources
+      enabled: true
+      values:
+        # mail server
+        smtp_host:
+          value_from:
+            env: ZITADEL_SMTP_HOST
+        # mail user
+        smtp_user:
+          value_from:
+            env: ZITADEL_SMTP_USER
+        # mail password
+        smtp_password:
+          value_from:
+            env: ZITADEL_SMTP_PASSWORD
     backups:
       s3:
         secret_access_key:

--- a/docs/k8s_apps/zitadel.md
+++ b/docs/k8s_apps/zitadel.md
@@ -60,6 +60,18 @@ apps:
         smtp_password:
           value_from:
             env: ZITADEL_SMTP_PASSWORD
+        # mail from address
+        smtp_from_address:
+          value_from:
+            env: ZITADEL_SMTP_FROM_ADDRESS
+        # mail from name
+        smtp_from_name:
+          value_from:
+            env: ZITADEL_SMTP_FROM_NAME
+        # mail reply to address
+        smtp_reply_to_address:
+          value_from:
+            env: ZITADEL_SMTP_REPLY_TO_ADDRESS
     backups:
       s3:
         secret_access_key:
@@ -172,6 +184,9 @@ apps:
         - ZITADEL_SMTP_HOST
         - ZITADEL_SMTP_USER
         - ZITADEL_SMTP_PASSWORD
+        - ZITADEL_SMTP_FROM_ADDRESS
+        - ZITADEL_SMTP_FROM_NAME
+        - ZITADEL_SMTP_REPLY_TO_ADDRESS
     init:
       # Switch to false if you don't want to create initial secrets or use the
       # API via a service account to create the above described resources
@@ -202,6 +217,18 @@ apps:
         smtp_password:
           value_from:
             env: ZITADEL_SMTP_PASSWORD
+        # mail from address
+        smtp_from_address:
+          value_from:
+            env: ZITADEL_SMTP_FROM_ADDRESS
+        # mail from name
+        smtp_from_name:
+          value_from:
+            env: ZITADEL_SMTP_FROM_NAME
+        # mail reply to address
+        smtp_reply_to_address:
+          value_from:
+            env: ZITADEL_SMTP_REPLY_TO_ADDRESS
       restore:
         enabled: false
         cnpg_restore: true

--- a/docs/k8s_apps/zitadel.md
+++ b/docs/k8s_apps/zitadel.md
@@ -166,10 +166,18 @@ apps:
         gender: GENDER_UNSPECIFIED
         # name of the default project to create OIDC applications in
         project: core
-        # coming soon after we refactor a bit
-        # smtp_password:
-        #   value_from:
-        #     env: ZITADEL_SMTP_PASSWORD
+        # mail server
+        smtp_host:
+          value_from:
+            env: ZITADEL_SMTP_HOST
+        # mail user
+        smtp_user:
+          value_from:
+            env: ZITADEL_SMTP_USER
+        # mail password
+        smtp_password:
+          value_from:
+            env: ZITADEL_SMTP_PASSWORD
       restore:
         enabled: false
         cnpg_restore: true

--- a/docs/k8s_apps/zitadel.md
+++ b/docs/k8s_apps/zitadel.md
@@ -152,14 +152,21 @@ apps:
         - ZITADEL_S3_BACKUP_ACCESS_ID
         - ZITADEL_S3_BACKUP_SECRET_KEY
         - ZITADEL_RESTIC_REPO_PASSWORD
+        - ZITADEL_SMTP_HOST
+        - ZITADEL_SMTP_USER
+        - ZITADEL_SMTP_PASSWORD
     init:
       # Switch to false if you don't want to create initial secrets or use the
       # API via a service account to create the above described resources
       enabled: true
       values:
+        # login username of admin user
         username: 'certainlynotadog'
+        # email of admin user
         email: 'notadog@humans.com'
+        # first name of admin user
         first_name: 'Dogsy'
+        # last name of admin user
         last_name: 'Dogerton'
         # options: GENDER_UNSPECIFIED, GENDER_MALE, GENDER_FEMALE, GENDER_DIVERSE
         # more coming soon, see: https://github.com/zitadel/zitadel/issues/6355

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "5.12.0"
+version       = "5.13.0"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -1748,7 +1748,7 @@ apps:
         gender: GENDER_UNSPECIFIED
         # name of the default project to create OIDC applications in
         project: core
-        # mail server
+        # mail server, must include port! e.g. mymailserver.com:587
         smtp_host:
           value_from:
             env: ZITADEL_SMTP_HOST
@@ -1760,6 +1760,18 @@ apps:
         smtp_password:
           value_from:
             env: ZITADEL_SMTP_PASSWORD
+        # mail from address
+        smtp_from_address:
+          value_from:
+            env: ZITADEL_SMTP_FROM_ADDRESS
+        # mail from name
+        smtp_from_name:
+          value_from:
+            env: ZITADEL_SMTP_FROM_NAME
+        # mail reply to address
+        smtp_reply_to_address:
+          value_from:
+            env: ZITADEL_SMTP_REPLY_TO_ADDRESS
     backups:
       # cronjob syntax schedule to run zitadel seaweedfs pvc backups
       pvc_schedule: 10 0 * * *

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -1748,6 +1748,18 @@ apps:
         gender: GENDER_UNSPECIFIED
         # name of the default project to create OIDC applications in
         project: core
+        # mail server
+        smtp_host:
+          value_from:
+            env: ZITADEL_SMTP_HOST
+        # mail user
+        smtp_user:
+          value_from:
+            env: ZITADEL_SMTP_USER
+        # mail password
+        smtp_password:
+          value_from:
+            env: ZITADEL_SMTP_PASSWORD
     backups:
       # cronjob syntax schedule to run zitadel seaweedfs pvc backups
       pvc_schedule: 10 0 * * *

--- a/smol_k8s_lab/k8s_apps/identity_provider/zitadel.py
+++ b/smol_k8s_lab/k8s_apps/identity_provider/zitadel.py
@@ -405,9 +405,9 @@ def setup_bitwarden_items(argocd: ArgoCD,
 
     # zitadel smtp credentials creation
     smtp_host_obj = create_custom_field('host', smtp_host)
-    smtp_from_address_obj = create_custom_field('host', smtp_from_address)
-    smtp_from_name_obj = create_custom_field('host', smtp_from_name)
-    smtp_reply_to_address_obj = create_custom_field('host', smtp_reply_to_address)
+    smtp_from_address_obj = create_custom_field('from_address', smtp_from_address)
+    smtp_from_name_obj = create_custom_field('from_name', smtp_from_name)
+    smtp_reply_to_address_obj = create_custom_field('reply_to_address', smtp_reply_to_address)
     smtp_id = bitwarden.create_login(
             name='zitadel-smtp-credentials',
             item_url=zitadel_hostname,

--- a/smol_k8s_lab/k8s_apps/social/matrix.py
+++ b/smol_k8s_lab/k8s_apps/social/matrix.py
@@ -270,22 +270,6 @@ def refresh_bweso(argocd: ArgoCD, matrix_hostname: str, bitwarden: BwCLI):
     ## BEGIN BRIDGES
 
     try:
-        hookshot_id = bitwarden.get_item(
-                f"matrix-hookshot-bridge-{matrix_hostname}", False
-                )[0]['id']
-    except TypeError:
-        log.info("No matrix hookshot bridge id found")
-        hookshot_id = "Not Applicable"
-
-    try:
-        hookshot_github_id = bitwarden.get_item(
-                f"matrix-hookshot-bridge-github-{matrix_hostname}", False
-                )[0]['id']
-    except TypeError:
-        log.info("No matrix hookshot github bridge id found")
-        hookshot_github_id = "Not Applicable"
-
-    try:
         alertmanager_id = bitwarden.get_item(
                 f"matrix-alertmanager-bridge-{matrix_hostname}", False
                 )[0]['id']
@@ -382,8 +366,6 @@ def refresh_bweso(argocd: ArgoCD, matrix_hostname: str, bitwarden: BwCLI):
              'matrix_oidc_credentials_bitwarden_id': oidc_id['id'],
              'matrix_discord_bitwarden_id': discord_id,
              'matrix_alertmanager_bitwarden_id': alertmanager_id,
-             'matrix_hookshot_bitwarden_id': hookshot_id,
-             'matrix_hookshot_github_bitwarden_id': hookshot_github_id,
              'matrix_idp_name': idp_name,
              'matrix_idp_id': idp_id})
 
@@ -534,32 +516,6 @@ def setup_bitwarden_items(argocd: ArgoCD,
             password=matrix_registration_key
             )
 
-    # hookshot bot passkey.pem and as_token + hs_token
-    hookshot_passkey_pem = bitwarden.generate()
-    hookshot_as_token = bitwarden.generate()
-    hookshot_as_token_obj = create_custom_field("as_token", hookshot_as_token)
-    hookshot_hs_token = bitwarden.generate()
-    hookshot_hs_token_obj = create_custom_field("hs_token", hookshot_hs_token)
-    hookshot_id = bitwarden.create_login(
-            name='matrix-hookshot-bridge',
-            item_url=matrix_hostname,
-            user="none",
-            note=hookshot_passkey_pem,
-            fields=[hookshot_as_token_obj, hookshot_hs_token_obj]
-            )
-
-    # hookshot bot github credentials
-    github_client_id_obj = create_custom_field("oauth_client_id", github_client_id)
-    github_client_secret_obj = create_custom_field("oauth_client_secret", github_client_secret)
-    hookshot_github_id = bitwarden.create_login(
-            name='matrix-hookshot-bridge',
-            item_url=matrix_hostname,
-            user=github_app_id,
-            password=github_webhook_secret,
-            note=github_private_key,
-            fields=[github_client_id_obj, github_client_secret_obj]
-            )
-
     # alert manager bot as_token + hs_token
     alertmanager_as_token = bitwarden.generate()
     alertmanager_as_token_obj = create_custom_field("as_token", alertmanager_as_token)
@@ -650,8 +606,6 @@ def setup_bitwarden_items(argocd: ArgoCD,
              'matrix_oidc_credentials_bitwarden_id': oidc_id,
              'matrix_authentication_service_bitwarden_id': mas_id,
              'matrix_alertmanager_bitwarden_id': alertmanager_id,
-             'matrix_hookshot_bitwarden_id': hookshot_id,
-             'matrix_hookshot_github_bitwarden_id': hookshot_github_id,
              'matrix_discord_bitwarden_id': discord_id,
              'matrix_idp_name': idp_name,
              'matrix_idp_id': idp_id}


### PR DESCRIPTION
- Removes creating secrets for the matrix Hookshot bridge, since we never got that to work
- Add SMTP credentials secret generation for Zitadel. In config.yaml you can now do:
  ```yaml
  apps:
    zitadel:
      enabled: true
      init:
        enabled: true
        values:
          # mail server
          smtp_host:
            value_from:
              env: ZITADEL_SMTP_HOST
          # mail user
          smtp_user:
            value_from:
              env: ZITADEL_SMTP_USER
          # mail password
          smtp_password:
            value_from:
              env: ZITADEL_SMTP_PASSWORD
          # mail from address
          smtp_from_address:
            value_from:
              env: ZITADEL_SMTP_FROM_ADDRESS
          # mail from name
          smtp_from_name:
            value_from:
              env: ZITADEL_SMTP_FROM_NAME
          # mail reply to address
          smtp_reply_to_address:
            value_from:
              env: ZITADEL_SMTP_REPLY_TO_ADDRESS
  ```
  
Relates to these commits in small-hack/argocd-apps:
- https://github.com/small-hack/argocd-apps/commit/c3febe808eb44d755740d23be41ba401caa89b36
- https://github.com/small-hack/argocd-apps/commit/4326f109e97896ddaab63797b6c278e471a0b630
- https://github.com/small-hack/argocd-apps/commit/e6818d0ba55667381fe28699bab5e4504cb1664c
- https://github.com/small-hack/argocd-apps/commit/462826585243393b8fcf41cad4e8047a1ba9f6d0