### PR TITLE
Enable pvc for mastodon's valkey component

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1409 562.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1019 611.1999999999999" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,131 +19,139 @@
         font-weight: 700;
     }
 
-    .terminal-2374144702-matrix {
+    .terminal-3473103371-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-2374144702-title {
+    .terminal-3473103371-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-2374144702-r1 { fill: #c5c8c6 }
-.terminal-2374144702-r2 { fill: #5f87ff }
-.terminal-2374144702-r3 { fill: #5f87af;font-style: italic; }
-.terminal-2374144702-r4 { fill: #5f87af }
-.terminal-2374144702-r5 { fill: #8787ff }
-.terminal-2374144702-r6 { fill: #afafff }
-.terminal-2374144702-r7 { fill: #87afff }
-.terminal-2374144702-r8 { fill: #afafff;font-weight: bold }
-.terminal-2374144702-r9 { fill: #868887 }
-.terminal-2374144702-r10 { fill: #6179a9 }
-.terminal-2374144702-r11 { fill: #6161a9 }
-.terminal-2374144702-r12 { fill: #7979a9;font-weight: bold }
-.terminal-2374144702-r13 { fill: #4961a9 }
+    .terminal-3473103371-r1 { fill: #c5c8c6 }
+.terminal-3473103371-r2 { fill: #5f87ff }
+.terminal-3473103371-r3 { fill: #5f87af;font-style: italic; }
+.terminal-3473103371-r4 { fill: #5f87af }
+.terminal-3473103371-r5 { fill: #8787ff }
+.terminal-3473103371-r6 { fill: #afafff }
+.terminal-3473103371-r7 { fill: #87afff }
+.terminal-3473103371-r8 { fill: #afafff;font-weight: bold }
+.terminal-3473103371-r9 { fill: #868887 }
+.terminal-3473103371-r10 { fill: #6179a9 }
+.terminal-3473103371-r11 { fill: #6161a9 }
+.terminal-3473103371-r12 { fill: #7979a9;font-weight: bold }
+.terminal-3473103371-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-2374144702-clip-terminal">
-      <rect x="0" y="0" width="1389.8" height="511.4" />
+    <clipPath id="terminal-3473103371-clip-terminal">
+      <rect x="0" y="0" width="999.4" height="560.1999999999999" />
     </clipPath>
-    <clipPath id="terminal-2374144702-line-0">
-    <rect x="0" y="1.5" width="1390.8" height="24.65"/>
+    <clipPath id="terminal-3473103371-line-0">
+    <rect x="0" y="1.5" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-1">
-    <rect x="0" y="25.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-1">
+    <rect x="0" y="25.9" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-2">
-    <rect x="0" y="50.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-2">
+    <rect x="0" y="50.3" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-3">
-    <rect x="0" y="74.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-3">
+    <rect x="0" y="74.7" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-4">
-    <rect x="0" y="99.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-4">
+    <rect x="0" y="99.1" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-5">
-    <rect x="0" y="123.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-5">
+    <rect x="0" y="123.5" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-6">
-    <rect x="0" y="147.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-6">
+    <rect x="0" y="147.9" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-7">
-    <rect x="0" y="172.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-7">
+    <rect x="0" y="172.3" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-8">
-    <rect x="0" y="196.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-8">
+    <rect x="0" y="196.7" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-9">
-    <rect x="0" y="221.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-9">
+    <rect x="0" y="221.1" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-10">
-    <rect x="0" y="245.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-10">
+    <rect x="0" y="245.5" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-11">
-    <rect x="0" y="269.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-11">
+    <rect x="0" y="269.9" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-12">
-    <rect x="0" y="294.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-12">
+    <rect x="0" y="294.3" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-13">
-    <rect x="0" y="318.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-13">
+    <rect x="0" y="318.7" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-14">
-    <rect x="0" y="343.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-14">
+    <rect x="0" y="343.1" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-15">
-    <rect x="0" y="367.5" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-15">
+    <rect x="0" y="367.5" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-16">
-    <rect x="0" y="391.9" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-16">
+    <rect x="0" y="391.9" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-17">
-    <rect x="0" y="416.3" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-17">
+    <rect x="0" y="416.3" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-18">
-    <rect x="0" y="440.7" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-18">
+    <rect x="0" y="440.7" width="1000.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2374144702-line-19">
-    <rect x="0" y="465.1" width="1390.8" height="24.65"/>
+<clipPath id="terminal-3473103371-line-19">
+    <rect x="0" y="465.1" width="1000.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3473103371-line-20">
+    <rect x="0" y="489.5" width="1000.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3473103371-line-21">
+    <rect x="0" y="513.9" width="1000.4" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1407" height="560.4" rx="8"/><text class="terminal-2374144702-title" fill="#c5c8c6" text-anchor="middle" x="703" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1017" height="609.2" rx="8"/><text class="terminal-3473103371-title" fill="#c5c8c6" text-anchor="middle" x="508" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-2374144702-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3473103371-clip-terminal)">
     
-    <g class="terminal-2374144702-matrix">
-    <text class="terminal-2374144702-r1" x="292.8" y="20" textLength="329.4" clip-path="url(#terminal-2374144702-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-2374144702-r2" x="634.4" y="20" textLength="146.4" clip-path="url(#terminal-2374144702-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-2374144702-r1" x="1390.8" y="20" textLength="12.2" clip-path="url(#terminal-2374144702-line-0)">
-</text><text class="terminal-2374144702-r1" x="1390.8" y="44.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-1)">
-</text><text class="terminal-2374144702-r3" x="292.8" y="68.8" textLength="793" clip-path="url(#terminal-2374144702-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-2374144702-r1" x="1390.8" y="68.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-2)">
-</text><text class="terminal-2374144702-r1" x="1390.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-3)">
-</text><text class="terminal-2374144702-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-2374144702-line-4)">Usage:</text><text class="terminal-2374144702-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-2374144702-line-4)">smol</text><text class="terminal-2374144702-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-4)">-k</text><text class="terminal-2374144702-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-4)">8s</text><text class="terminal-2374144702-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-4)">-l</text><text class="terminal-2374144702-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-4)">ab</text><text class="terminal-2374144702-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-2374144702-line-4)">[OPTIONS]</text><text class="terminal-2374144702-r1" x="1390.8" y="117.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-4)">
-</text><text class="terminal-2374144702-r1" x="1390.8" y="142" textLength="12.2" clip-path="url(#terminal-2374144702-line-5)">
-</text><text class="terminal-2374144702-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-2374144702-line-6)">╭─</text><text class="terminal-2374144702-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-2374144702-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-2374144702-r6" x="219.6" y="166.4" textLength="1146.8" clip-path="url(#terminal-2374144702-line-6)">──────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-2374144702-r6" x="1366.4" y="166.4" textLength="24.4" clip-path="url(#terminal-2374144702-line-6)">─╮</text><text class="terminal-2374144702-r1" x="1390.8" y="166.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-6)">
-</text><text class="terminal-2374144702-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-7)">│</text><text class="terminal-2374144702-r6" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-7)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="190.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-7)">
-</text><text class="terminal-2374144702-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-8)">│</text><text class="terminal-2374144702-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-2374144702-line-8)">-c</text><text class="terminal-2374144702-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-8)">-</text><text class="terminal-2374144702-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-2374144702-line-8)">-c</text><text class="terminal-2374144702-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-2374144702-line-8)">onfig</text><text class="terminal-2374144702-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-2374144702-line-8)">&#160;CONFIG_FILE</text><text class="terminal-2374144702-r1" x="329.4" y="215.2" textLength="780.8" clip-path="url(#terminal-2374144702-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2374144702-r6" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-8)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="215.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-8)">
-</text><text class="terminal-2374144702-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-9)">│</text><text class="terminal-2374144702-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-2374144702-line-9)">Defaults&#160;to&#160;</text><text class="terminal-2374144702-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-2374144702-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-2374144702-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-2374144702-line-9)">smol</text><text class="terminal-2374144702-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-9)">-k</text><text class="terminal-2374144702-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-9)">8s</text><text class="terminal-2374144702-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-9)">-l</text><text class="terminal-2374144702-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-9)">ab</text><text class="terminal-2374144702-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-2374144702-line-9)">/config.yaml</text><text class="terminal-2374144702-r6" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-9)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="239.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-9)">
-</text><text class="terminal-2374144702-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-2374144702-line-10)">│</text><text class="terminal-2374144702-r6" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-2374144702-line-10)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="264" textLength="12.2" clip-path="url(#terminal-2374144702-line-10)">
-</text><text class="terminal-2374144702-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-11)">│</text><text class="terminal-2374144702-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-2374144702-line-11)">-D</text><text class="terminal-2374144702-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-11)">-</text><text class="terminal-2374144702-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-2374144702-line-11)">-d</text><text class="terminal-2374144702-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-2374144702-line-11)">elete</text><text class="terminal-2374144702-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-2374144702-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-2374144702-r9" x="329.4" y="288.4" textLength="780.8" clip-path="url(#terminal-2374144702-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2374144702-r6" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-11)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="288.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-11)">
-</text><text class="terminal-2374144702-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-12)">│</text><text class="terminal-2374144702-r6" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-12)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="312.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-12)">
-</text><text class="terminal-2374144702-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-13)">│</text><text class="terminal-2374144702-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-2374144702-line-13)">-i</text><text class="terminal-2374144702-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-13)">-</text><text class="terminal-2374144702-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-2374144702-line-13)">-i</text><text class="terminal-2374144702-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-2374144702-line-13)">nteractive</text><text class="terminal-2374144702-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-2374144702-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-2374144702-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-2374144702-line-13)">smol</text><text class="terminal-2374144702-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-2374144702-line-13)">-k</text><text class="terminal-2374144702-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-2374144702-line-13)">8s</text><text class="terminal-2374144702-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-2374144702-line-13)">-l</text><text class="terminal-2374144702-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-2374144702-line-13)">ab</text><text class="terminal-2374144702-r6" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-13)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="337.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-13)">
-</text><text class="terminal-2374144702-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-14)">│</text><text class="terminal-2374144702-r6" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-14)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="361.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-14)">
-</text><text class="terminal-2374144702-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-2374144702-line-15)">│</text><text class="terminal-2374144702-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-2374144702-line-15)">-v</text><text class="terminal-2374144702-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-2374144702-line-15)">-</text><text class="terminal-2374144702-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-2374144702-line-15)">-v</text><text class="terminal-2374144702-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-2374144702-line-15)">ersion</text><text class="terminal-2374144702-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-2374144702-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-2374144702-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-2374144702-line-15)">smol</text><text class="terminal-2374144702-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-2374144702-line-15)">-k</text><text class="terminal-2374144702-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-2374144702-line-15)">8s</text><text class="terminal-2374144702-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-2374144702-line-15)">-l</text><text class="terminal-2374144702-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-2374144702-line-15)">ab</text><text class="terminal-2374144702-r9" x="732" y="386" textLength="378.2" clip-path="url(#terminal-2374144702-line-15)">&#160;(v5.17.2)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2374144702-r6" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-2374144702-line-15)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="386" textLength="12.2" clip-path="url(#terminal-2374144702-line-15)">
-</text><text class="terminal-2374144702-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-16)">│</text><text class="terminal-2374144702-r6" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-16)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="410.4" textLength="12.2" clip-path="url(#terminal-2374144702-line-16)">
-</text><text class="terminal-2374144702-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-17)">│</text><text class="terminal-2374144702-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-2374144702-line-17)">-f</text><text class="terminal-2374144702-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-17)">-</text><text class="terminal-2374144702-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-2374144702-line-17)">-f</text><text class="terminal-2374144702-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-2374144702-line-17)">inal_cmd</text><text class="terminal-2374144702-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-2374144702-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-2374144702-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-2374144702-line-17)">smol</text><text class="terminal-2374144702-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-2374144702-line-17)">-k</text><text class="terminal-2374144702-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-2374144702-line-17)">8s</text><text class="terminal-2374144702-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-2374144702-line-17)">-l</text><text class="terminal-2374144702-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-2374144702-line-17)">ab</text><text class="terminal-2374144702-r1" x="841.8" y="434.8" textLength="268.4" clip-path="url(#terminal-2374144702-line-17)">&#160;before&#160;main&#160;cli&#160;phase</text><text class="terminal-2374144702-r6" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-17)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="434.8" textLength="12.2" clip-path="url(#terminal-2374144702-line-17)">
-</text><text class="terminal-2374144702-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-18)">│</text><text class="terminal-2374144702-r6" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-18)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="459.2" textLength="12.2" clip-path="url(#terminal-2374144702-line-18)">
-</text><text class="terminal-2374144702-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-19)">│</text><text class="terminal-2374144702-r10" x="24.4" y="483.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-19)">-h</text><text class="terminal-2374144702-r11" x="61" y="483.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-19)">-</text><text class="terminal-2374144702-r11" x="73.2" y="483.6" textLength="24.4" clip-path="url(#terminal-2374144702-line-19)">-h</text><text class="terminal-2374144702-r11" x="97.6" y="483.6" textLength="36.6" clip-path="url(#terminal-2374144702-line-19)">elp</text><text class="terminal-2374144702-r9" x="329.4" y="483.6" textLength="780.8" clip-path="url(#terminal-2374144702-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2374144702-r6" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-19)">│</text><text class="terminal-2374144702-r1" x="1390.8" y="483.6" textLength="12.2" clip-path="url(#terminal-2374144702-line-19)">
-</text><text class="terminal-2374144702-r6" x="0" y="508" textLength="24.4" clip-path="url(#terminal-2374144702-line-20)">╰─</text><text class="terminal-2374144702-r6" x="24.4" y="508" textLength="719.8" clip-path="url(#terminal-2374144702-line-20)">───────────────────────────────────────────────────────────</text><text class="terminal-2374144702-r6" x="744.2" y="508" textLength="109.8" clip-path="url(#terminal-2374144702-line-20)">&#160;♥&#160;docs:&#160;</text><text class="terminal-2374144702-r6" x="854" y="508" textLength="500.2" clip-path="url(#terminal-2374144702-line-20)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-2374144702-r6" x="1366.4" y="508" textLength="24.4" clip-path="url(#terminal-2374144702-line-20)">─╯</text><text class="terminal-2374144702-r1" x="1390.8" y="508" textLength="12.2" clip-path="url(#terminal-2374144702-line-20)">
+    <g class="terminal-3473103371-matrix">
+    <text class="terminal-3473103371-r1" x="97.6" y="20" textLength="329.4" clip-path="url(#terminal-3473103371-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-3473103371-r2" x="439.2" y="20" textLength="146.4" clip-path="url(#terminal-3473103371-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-3473103371-r1" x="1000.4" y="20" textLength="12.2" clip-path="url(#terminal-3473103371-line-0)">
+</text><text class="terminal-3473103371-r1" x="1000.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-1)">
+</text><text class="terminal-3473103371-r3" x="97.6" y="68.8" textLength="793" clip-path="url(#terminal-3473103371-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-3473103371-r1" x="1000.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-2)">
+</text><text class="terminal-3473103371-r1" x="1000.4" y="93.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-3)">
+</text><text class="terminal-3473103371-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-3473103371-line-4)">Usage:</text><text class="terminal-3473103371-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-3473103371-line-4)">smol</text><text class="terminal-3473103371-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-4)">-k</text><text class="terminal-3473103371-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-4)">8s</text><text class="terminal-3473103371-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-4)">-l</text><text class="terminal-3473103371-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-4)">ab</text><text class="terminal-3473103371-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-3473103371-line-4)">[OPTIONS]</text><text class="terminal-3473103371-r1" x="1000.4" y="117.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-4)">
+</text><text class="terminal-3473103371-r1" x="1000.4" y="142" textLength="12.2" clip-path="url(#terminal-3473103371-line-5)">
+</text><text class="terminal-3473103371-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-6)">╭─</text><text class="terminal-3473103371-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-3473103371-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-3473103371-r6" x="219.6" y="166.4" textLength="756.4" clip-path="url(#terminal-3473103371-line-6)">──────────────────────────────────────────────────────────────</text><text class="terminal-3473103371-r6" x="976" y="166.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-6)">─╮</text><text class="terminal-3473103371-r1" x="1000.4" y="166.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-6)">
+</text><text class="terminal-3473103371-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-7)">│</text><text class="terminal-3473103371-r6" x="988.2" y="190.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-7)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="190.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-7)">
+</text><text class="terminal-3473103371-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-8)">│</text><text class="terminal-3473103371-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-3473103371-line-8)">-c</text><text class="terminal-3473103371-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-8)">-</text><text class="terminal-3473103371-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-3473103371-line-8)">-c</text><text class="terminal-3473103371-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-3473103371-line-8)">onfig</text><text class="terminal-3473103371-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-3473103371-line-8)">&#160;CONFIG_FILE</text><text class="terminal-3473103371-r1" x="329.4" y="215.2" textLength="634.4" clip-path="url(#terminal-3473103371-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.</text><text class="terminal-3473103371-r6" x="988.2" y="215.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-8)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-8)">
+</text><text class="terminal-3473103371-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-9)">│</text><text class="terminal-3473103371-r1" x="329.4" y="239.6" textLength="634.4" clip-path="url(#terminal-3473103371-line-9)">Defaults&#160;to&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3473103371-r6" x="988.2" y="239.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-9)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="239.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-9)">
+</text><text class="terminal-3473103371-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3473103371-line-10)">│</text><text class="terminal-3473103371-r6" x="329.4" y="264" textLength="207.4" clip-path="url(#terminal-3473103371-line-10)">$XDG_CONFIG_HOME/</text><text class="terminal-3473103371-r2" x="536.8" y="264" textLength="48.8" clip-path="url(#terminal-3473103371-line-10)">smol</text><text class="terminal-3473103371-r2" x="585.6" y="264" textLength="24.4" clip-path="url(#terminal-3473103371-line-10)">-k</text><text class="terminal-3473103371-r2" x="610" y="264" textLength="24.4" clip-path="url(#terminal-3473103371-line-10)">8s</text><text class="terminal-3473103371-r2" x="634.4" y="264" textLength="24.4" clip-path="url(#terminal-3473103371-line-10)">-l</text><text class="terminal-3473103371-r2" x="658.8" y="264" textLength="24.4" clip-path="url(#terminal-3473103371-line-10)">ab</text><text class="terminal-3473103371-r6" x="683.2" y="264" textLength="146.4" clip-path="url(#terminal-3473103371-line-10)">/config.yaml</text><text class="terminal-3473103371-r6" x="988.2" y="264" textLength="12.2" clip-path="url(#terminal-3473103371-line-10)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="264" textLength="12.2" clip-path="url(#terminal-3473103371-line-10)">
+</text><text class="terminal-3473103371-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-11)">│</text><text class="terminal-3473103371-r6" x="988.2" y="288.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-11)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="288.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-11)">
+</text><text class="terminal-3473103371-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-12)">│</text><text class="terminal-3473103371-r10" x="24.4" y="312.8" textLength="24.4" clip-path="url(#terminal-3473103371-line-12)">-D</text><text class="terminal-3473103371-r11" x="61" y="312.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-12)">-</text><text class="terminal-3473103371-r11" x="73.2" y="312.8" textLength="24.4" clip-path="url(#terminal-3473103371-line-12)">-d</text><text class="terminal-3473103371-r11" x="97.6" y="312.8" textLength="61" clip-path="url(#terminal-3473103371-line-12)">elete</text><text class="terminal-3473103371-r12" x="158.6" y="312.8" textLength="158.6" clip-path="url(#terminal-3473103371-line-12)">&#160;CLUSTER_NAME</text><text class="terminal-3473103371-r9" x="329.4" y="312.8" textLength="634.4" clip-path="url(#terminal-3473103371-line-12)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3473103371-r6" x="988.2" y="312.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-12)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="312.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-12)">
+</text><text class="terminal-3473103371-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-13)">│</text><text class="terminal-3473103371-r6" x="988.2" y="337.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-13)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="337.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-13)">
+</text><text class="terminal-3473103371-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-14)">│</text><text class="terminal-3473103371-r7" x="24.4" y="361.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-14)">-i</text><text class="terminal-3473103371-r5" x="61" y="361.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-14)">-</text><text class="terminal-3473103371-r5" x="73.2" y="361.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-14)">-i</text><text class="terminal-3473103371-r5" x="97.6" y="361.6" textLength="122" clip-path="url(#terminal-3473103371-line-14)">nteractive</text><text class="terminal-3473103371-r1" x="329.4" y="361.6" textLength="341.6" clip-path="url(#terminal-3473103371-line-14)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-3473103371-r2" x="658.8" y="361.6" textLength="48.8" clip-path="url(#terminal-3473103371-line-14)">smol</text><text class="terminal-3473103371-r2" x="707.6" y="361.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-14)">-k</text><text class="terminal-3473103371-r2" x="732" y="361.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-14)">8s</text><text class="terminal-3473103371-r2" x="756.4" y="361.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-14)">-l</text><text class="terminal-3473103371-r2" x="780.8" y="361.6" textLength="24.4" clip-path="url(#terminal-3473103371-line-14)">ab</text><text class="terminal-3473103371-r6" x="988.2" y="361.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-14)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="361.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-14)">
+</text><text class="terminal-3473103371-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-3473103371-line-15)">│</text><text class="terminal-3473103371-r6" x="988.2" y="386" textLength="12.2" clip-path="url(#terminal-3473103371-line-15)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="386" textLength="12.2" clip-path="url(#terminal-3473103371-line-15)">
+</text><text class="terminal-3473103371-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-16)">│</text><text class="terminal-3473103371-r10" x="24.4" y="410.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-16)">-v</text><text class="terminal-3473103371-r11" x="61" y="410.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-16)">-</text><text class="terminal-3473103371-r11" x="73.2" y="410.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-16)">-v</text><text class="terminal-3473103371-r11" x="97.6" y="410.4" textLength="73.2" clip-path="url(#terminal-3473103371-line-16)">ersion</text><text class="terminal-3473103371-r9" x="329.4" y="410.4" textLength="256.2" clip-path="url(#terminal-3473103371-line-16)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-3473103371-r13" x="585.6" y="410.4" textLength="48.8" clip-path="url(#terminal-3473103371-line-16)">smol</text><text class="terminal-3473103371-r13" x="634.4" y="410.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-16)">-k</text><text class="terminal-3473103371-r13" x="658.8" y="410.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-16)">8s</text><text class="terminal-3473103371-r13" x="683.2" y="410.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-16)">-l</text><text class="terminal-3473103371-r13" x="707.6" y="410.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-16)">ab</text><text class="terminal-3473103371-r9" x="732" y="410.4" textLength="231.8" clip-path="url(#terminal-3473103371-line-16)">&#160;(v5.17.3)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3473103371-r6" x="988.2" y="410.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-16)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="410.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-16)">
+</text><text class="terminal-3473103371-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-17)">│</text><text class="terminal-3473103371-r6" x="988.2" y="434.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-17)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="434.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-17)">
+</text><text class="terminal-3473103371-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-18)">│</text><text class="terminal-3473103371-r7" x="24.4" y="459.2" textLength="24.4" clip-path="url(#terminal-3473103371-line-18)">-f</text><text class="terminal-3473103371-r5" x="61" y="459.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-18)">-</text><text class="terminal-3473103371-r5" x="73.2" y="459.2" textLength="24.4" clip-path="url(#terminal-3473103371-line-18)">-f</text><text class="terminal-3473103371-r5" x="97.6" y="459.2" textLength="97.6" clip-path="url(#terminal-3473103371-line-18)">inal_cmd</text><text class="terminal-3473103371-r1" x="329.4" y="459.2" textLength="366" clip-path="url(#terminal-3473103371-line-18)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-3473103371-r2" x="695.4" y="459.2" textLength="48.8" clip-path="url(#terminal-3473103371-line-18)">smol</text><text class="terminal-3473103371-r2" x="744.2" y="459.2" textLength="24.4" clip-path="url(#terminal-3473103371-line-18)">-k</text><text class="terminal-3473103371-r2" x="768.6" y="459.2" textLength="24.4" clip-path="url(#terminal-3473103371-line-18)">8s</text><text class="terminal-3473103371-r2" x="793" y="459.2" textLength="24.4" clip-path="url(#terminal-3473103371-line-18)">-l</text><text class="terminal-3473103371-r2" x="817.4" y="459.2" textLength="24.4" clip-path="url(#terminal-3473103371-line-18)">ab</text><text class="terminal-3473103371-r1" x="841.8" y="459.2" textLength="122" clip-path="url(#terminal-3473103371-line-18)">&#160;before&#160;&#160;&#160;</text><text class="terminal-3473103371-r6" x="988.2" y="459.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-18)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="459.2" textLength="12.2" clip-path="url(#terminal-3473103371-line-18)">
+</text><text class="terminal-3473103371-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-19)">│</text><text class="terminal-3473103371-r1" x="329.4" y="483.6" textLength="634.4" clip-path="url(#terminal-3473103371-line-19)">main&#160;cli&#160;phase&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3473103371-r6" x="988.2" y="483.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-19)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="483.6" textLength="12.2" clip-path="url(#terminal-3473103371-line-19)">
+</text><text class="terminal-3473103371-r6" x="0" y="508" textLength="12.2" clip-path="url(#terminal-3473103371-line-20)">│</text><text class="terminal-3473103371-r6" x="988.2" y="508" textLength="12.2" clip-path="url(#terminal-3473103371-line-20)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="508" textLength="12.2" clip-path="url(#terminal-3473103371-line-20)">
+</text><text class="terminal-3473103371-r6" x="0" y="532.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-21)">│</text><text class="terminal-3473103371-r10" x="24.4" y="532.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-21)">-h</text><text class="terminal-3473103371-r11" x="61" y="532.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-21)">-</text><text class="terminal-3473103371-r11" x="73.2" y="532.4" textLength="24.4" clip-path="url(#terminal-3473103371-line-21)">-h</text><text class="terminal-3473103371-r11" x="97.6" y="532.4" textLength="36.6" clip-path="url(#terminal-3473103371-line-21)">elp</text><text class="terminal-3473103371-r9" x="329.4" y="532.4" textLength="634.4" clip-path="url(#terminal-3473103371-line-21)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3473103371-r6" x="988.2" y="532.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-21)">│</text><text class="terminal-3473103371-r1" x="1000.4" y="532.4" textLength="12.2" clip-path="url(#terminal-3473103371-line-21)">
+</text><text class="terminal-3473103371-r6" x="0" y="556.8" textLength="24.4" clip-path="url(#terminal-3473103371-line-22)">╰─</text><text class="terminal-3473103371-r6" x="24.4" y="556.8" textLength="329.4" clip-path="url(#terminal-3473103371-line-22)">───────────────────────────</text><text class="terminal-3473103371-r6" x="353.8" y="556.8" textLength="109.8" clip-path="url(#terminal-3473103371-line-22)">&#160;♥&#160;docs:&#160;</text><text class="terminal-3473103371-r6" x="463.6" y="556.8" textLength="500.2" clip-path="url(#terminal-3473103371-line-22)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-3473103371-r6" x="976" y="556.8" textLength="24.4" clip-path="url(#terminal-3473103371-line-22)">─╯</text><text class="terminal-3473103371-r1" x="1000.4" y="556.8" textLength="12.2" clip-path="url(#terminal-3473103371-line-22)">
 </text>
     </g>
     </g>

--- a/docs/k8s_apps/mastodon.md
+++ b/docs/k8s_apps/mastodon.md
@@ -119,6 +119,8 @@ apps:
         # local s3 endpoint for postgresql backups, backed up constantly
         s3_endpoint: ""
         s3_region: eu-west-1
+        # enable persistence for valkey - recommended
+        valkey_pvc_enabled: 'true'
         # size of valkey pvc storage settings
         valkey_storage: 3Gi
         valkey_storage_class: local-path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "5.17.2"
+version       = "5.17.3"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -851,6 +851,8 @@ apps:
         # local s3 endpoint for postgresql backups, backed up constantly
         s3_endpoint: ""
         s3_region: eu-west-1
+        # enable persistence for valkey - recommended
+        valkey_pvc_enabled: 'true'
         # size of valkey pvc storage
         valkey_storage: 3Gi
         valkey_storage_class: local-path


### PR DESCRIPTION
Adds the following option:

```yaml
apps:
  mastodon:
    argo:
      # secrets keys to make available to Argo CD ApplicationSets
      secret_keys:
        # enable persistence for valkey - recommended
        valkey_pvc_enabled: 'true'
```