### PR TITLE
Add smtp port for mastodon, add valkey restore to `restore_mastodon`, and update textual + rich

### DIFF
--- a/docs/assets/images/screenshots/help_text.svg
+++ b/docs/assets/images/screenshots/help_text.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1019 611.1999999999999" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1141 586.8" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,139 +19,135 @@
         font-weight: 700;
     }
 
-    .terminal-3736820236-matrix {
+    .terminal-1097805467-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3736820236-title {
+    .terminal-1097805467-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3736820236-r1 { fill: #c5c8c6 }
-.terminal-3736820236-r2 { fill: #5f87ff }
-.terminal-3736820236-r3 { fill: #5f87af;font-style: italic; }
-.terminal-3736820236-r4 { fill: #5f87af }
-.terminal-3736820236-r5 { fill: #8787ff }
-.terminal-3736820236-r6 { fill: #afafff }
-.terminal-3736820236-r7 { fill: #87afff }
-.terminal-3736820236-r8 { fill: #afafff;font-weight: bold }
-.terminal-3736820236-r9 { fill: #868887 }
-.terminal-3736820236-r10 { fill: #6179a9 }
-.terminal-3736820236-r11 { fill: #6161a9 }
-.terminal-3736820236-r12 { fill: #7979a9;font-weight: bold }
-.terminal-3736820236-r13 { fill: #4961a9 }
+    .terminal-1097805467-r1 { fill: #c5c8c6 }
+.terminal-1097805467-r2 { fill: #5f87ff }
+.terminal-1097805467-r3 { fill: #5f87af;font-style: italic; }
+.terminal-1097805467-r4 { fill: #5f87af }
+.terminal-1097805467-r5 { fill: #8787ff }
+.terminal-1097805467-r6 { fill: #afafff }
+.terminal-1097805467-r7 { fill: #87afff }
+.terminal-1097805467-r8 { fill: #afafff;font-weight: bold }
+.terminal-1097805467-r9 { fill: #868887 }
+.terminal-1097805467-r10 { fill: #6179a9 }
+.terminal-1097805467-r11 { fill: #6161a9 }
+.terminal-1097805467-r12 { fill: #7979a9;font-weight: bold }
+.terminal-1097805467-r13 { fill: #4961a9 }
     </style>
 
     <defs>
-    <clipPath id="terminal-3736820236-clip-terminal">
-      <rect x="0" y="0" width="999.4" height="560.1999999999999" />
+    <clipPath id="terminal-1097805467-clip-terminal">
+      <rect x="0" y="0" width="1121.3999999999999" height="535.8" />
     </clipPath>
-    <clipPath id="terminal-3736820236-line-0">
-    <rect x="0" y="1.5" width="1000.4" height="24.65"/>
+    <clipPath id="terminal-1097805467-line-0">
+    <rect x="0" y="1.5" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-1">
-    <rect x="0" y="25.9" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-1">
+    <rect x="0" y="25.9" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-2">
-    <rect x="0" y="50.3" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-2">
+    <rect x="0" y="50.3" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-3">
-    <rect x="0" y="74.7" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-3">
+    <rect x="0" y="74.7" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-4">
-    <rect x="0" y="99.1" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-4">
+    <rect x="0" y="99.1" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-5">
-    <rect x="0" y="123.5" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-5">
+    <rect x="0" y="123.5" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-6">
-    <rect x="0" y="147.9" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-6">
+    <rect x="0" y="147.9" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-7">
-    <rect x="0" y="172.3" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-7">
+    <rect x="0" y="172.3" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-8">
-    <rect x="0" y="196.7" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-8">
+    <rect x="0" y="196.7" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-9">
-    <rect x="0" y="221.1" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-9">
+    <rect x="0" y="221.1" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-10">
-    <rect x="0" y="245.5" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-10">
+    <rect x="0" y="245.5" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-11">
-    <rect x="0" y="269.9" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-11">
+    <rect x="0" y="269.9" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-12">
-    <rect x="0" y="294.3" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-12">
+    <rect x="0" y="294.3" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-13">
-    <rect x="0" y="318.7" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-13">
+    <rect x="0" y="318.7" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-14">
-    <rect x="0" y="343.1" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-14">
+    <rect x="0" y="343.1" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-15">
-    <rect x="0" y="367.5" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-15">
+    <rect x="0" y="367.5" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-16">
-    <rect x="0" y="391.9" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-16">
+    <rect x="0" y="391.9" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-17">
-    <rect x="0" y="416.3" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-17">
+    <rect x="0" y="416.3" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-18">
-    <rect x="0" y="440.7" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-18">
+    <rect x="0" y="440.7" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-19">
-    <rect x="0" y="465.1" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-19">
+    <rect x="0" y="465.1" width="1122.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3736820236-line-20">
-    <rect x="0" y="489.5" width="1000.4" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-3736820236-line-21">
-    <rect x="0" y="513.9" width="1000.4" height="24.65"/>
+<clipPath id="terminal-1097805467-line-20">
+    <rect x="0" y="489.5" width="1122.4" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1017" height="609.2" rx="8"/><text class="terminal-3736820236-title" fill="#c5c8c6" text-anchor="middle" x="508" y="27">term</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1139" height="584.8" rx="8"/><text class="terminal-1097805467-title" fill="#c5c8c6" text-anchor="middle" x="569" y="27">term</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3736820236-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1097805467-clip-terminal)">
     
-    <g class="terminal-3736820236-matrix">
-    <text class="terminal-3736820236-r1" x="97.6" y="20" textLength="329.4" clip-path="url(#terminal-3736820236-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-3736820236-r2" x="439.2" y="20" textLength="146.4" clip-path="url(#terminal-3736820236-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-3736820236-r1" x="1000.4" y="20" textLength="12.2" clip-path="url(#terminal-3736820236-line-0)">
-</text><text class="terminal-3736820236-r1" x="1000.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-1)">
-</text><text class="terminal-3736820236-r3" x="97.6" y="68.8" textLength="793" clip-path="url(#terminal-3736820236-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-3736820236-r1" x="1000.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-2)">
-</text><text class="terminal-3736820236-r1" x="1000.4" y="93.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-3)">
-</text><text class="terminal-3736820236-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-3736820236-line-4)">Usage:</text><text class="terminal-3736820236-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-3736820236-line-4)">smol</text><text class="terminal-3736820236-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-4)">-k</text><text class="terminal-3736820236-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-4)">8s</text><text class="terminal-3736820236-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-4)">-l</text><text class="terminal-3736820236-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-4)">ab</text><text class="terminal-3736820236-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-3736820236-line-4)">[OPTIONS]</text><text class="terminal-3736820236-r1" x="1000.4" y="117.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-4)">
-</text><text class="terminal-3736820236-r1" x="1000.4" y="142" textLength="12.2" clip-path="url(#terminal-3736820236-line-5)">
-</text><text class="terminal-3736820236-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-6)">╭─</text><text class="terminal-3736820236-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-3736820236-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-3736820236-r6" x="219.6" y="166.4" textLength="756.4" clip-path="url(#terminal-3736820236-line-6)">──────────────────────────────────────────────────────────────</text><text class="terminal-3736820236-r6" x="976" y="166.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-6)">─╮</text><text class="terminal-3736820236-r1" x="1000.4" y="166.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-6)">
-</text><text class="terminal-3736820236-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-7)">│</text><text class="terminal-3736820236-r6" x="988.2" y="190.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-7)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="190.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-7)">
-</text><text class="terminal-3736820236-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-8)">│</text><text class="terminal-3736820236-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-3736820236-line-8)">-c</text><text class="terminal-3736820236-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-8)">-</text><text class="terminal-3736820236-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-3736820236-line-8)">-c</text><text class="terminal-3736820236-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-3736820236-line-8)">onfig</text><text class="terminal-3736820236-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-3736820236-line-8)">&#160;CONFIG_FILE</text><text class="terminal-3736820236-r1" x="329.4" y="215.2" textLength="634.4" clip-path="url(#terminal-3736820236-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.</text><text class="terminal-3736820236-r6" x="988.2" y="215.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-8)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-8)">
-</text><text class="terminal-3736820236-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-9)">│</text><text class="terminal-3736820236-r1" x="329.4" y="239.6" textLength="634.4" clip-path="url(#terminal-3736820236-line-9)">Defaults&#160;to&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3736820236-r6" x="988.2" y="239.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-9)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="239.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-9)">
-</text><text class="terminal-3736820236-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3736820236-line-10)">│</text><text class="terminal-3736820236-r6" x="329.4" y="264" textLength="207.4" clip-path="url(#terminal-3736820236-line-10)">$XDG_CONFIG_HOME/</text><text class="terminal-3736820236-r2" x="536.8" y="264" textLength="48.8" clip-path="url(#terminal-3736820236-line-10)">smol</text><text class="terminal-3736820236-r2" x="585.6" y="264" textLength="24.4" clip-path="url(#terminal-3736820236-line-10)">-k</text><text class="terminal-3736820236-r2" x="610" y="264" textLength="24.4" clip-path="url(#terminal-3736820236-line-10)">8s</text><text class="terminal-3736820236-r2" x="634.4" y="264" textLength="24.4" clip-path="url(#terminal-3736820236-line-10)">-l</text><text class="terminal-3736820236-r2" x="658.8" y="264" textLength="24.4" clip-path="url(#terminal-3736820236-line-10)">ab</text><text class="terminal-3736820236-r6" x="683.2" y="264" textLength="146.4" clip-path="url(#terminal-3736820236-line-10)">/config.yaml</text><text class="terminal-3736820236-r6" x="988.2" y="264" textLength="12.2" clip-path="url(#terminal-3736820236-line-10)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="264" textLength="12.2" clip-path="url(#terminal-3736820236-line-10)">
-</text><text class="terminal-3736820236-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-11)">│</text><text class="terminal-3736820236-r6" x="988.2" y="288.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-11)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="288.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-11)">
-</text><text class="terminal-3736820236-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-12)">│</text><text class="terminal-3736820236-r10" x="24.4" y="312.8" textLength="24.4" clip-path="url(#terminal-3736820236-line-12)">-D</text><text class="terminal-3736820236-r11" x="61" y="312.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-12)">-</text><text class="terminal-3736820236-r11" x="73.2" y="312.8" textLength="24.4" clip-path="url(#terminal-3736820236-line-12)">-d</text><text class="terminal-3736820236-r11" x="97.6" y="312.8" textLength="61" clip-path="url(#terminal-3736820236-line-12)">elete</text><text class="terminal-3736820236-r12" x="158.6" y="312.8" textLength="158.6" clip-path="url(#terminal-3736820236-line-12)">&#160;CLUSTER_NAME</text><text class="terminal-3736820236-r9" x="329.4" y="312.8" textLength="634.4" clip-path="url(#terminal-3736820236-line-12)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3736820236-r6" x="988.2" y="312.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-12)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="312.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-12)">
-</text><text class="terminal-3736820236-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-13)">│</text><text class="terminal-3736820236-r6" x="988.2" y="337.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-13)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="337.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-13)">
-</text><text class="terminal-3736820236-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-14)">│</text><text class="terminal-3736820236-r7" x="24.4" y="361.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-14)">-i</text><text class="terminal-3736820236-r5" x="61" y="361.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-14)">-</text><text class="terminal-3736820236-r5" x="73.2" y="361.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-14)">-i</text><text class="terminal-3736820236-r5" x="97.6" y="361.6" textLength="122" clip-path="url(#terminal-3736820236-line-14)">nteractive</text><text class="terminal-3736820236-r1" x="329.4" y="361.6" textLength="341.6" clip-path="url(#terminal-3736820236-line-14)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-3736820236-r2" x="658.8" y="361.6" textLength="48.8" clip-path="url(#terminal-3736820236-line-14)">smol</text><text class="terminal-3736820236-r2" x="707.6" y="361.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-14)">-k</text><text class="terminal-3736820236-r2" x="732" y="361.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-14)">8s</text><text class="terminal-3736820236-r2" x="756.4" y="361.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-14)">-l</text><text class="terminal-3736820236-r2" x="780.8" y="361.6" textLength="24.4" clip-path="url(#terminal-3736820236-line-14)">ab</text><text class="terminal-3736820236-r6" x="988.2" y="361.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-14)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="361.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-14)">
-</text><text class="terminal-3736820236-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-3736820236-line-15)">│</text><text class="terminal-3736820236-r6" x="988.2" y="386" textLength="12.2" clip-path="url(#terminal-3736820236-line-15)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="386" textLength="12.2" clip-path="url(#terminal-3736820236-line-15)">
-</text><text class="terminal-3736820236-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-16)">│</text><text class="terminal-3736820236-r10" x="24.4" y="410.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-16)">-v</text><text class="terminal-3736820236-r11" x="61" y="410.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-16)">-</text><text class="terminal-3736820236-r11" x="73.2" y="410.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-16)">-v</text><text class="terminal-3736820236-r11" x="97.6" y="410.4" textLength="73.2" clip-path="url(#terminal-3736820236-line-16)">ersion</text><text class="terminal-3736820236-r9" x="329.4" y="410.4" textLength="256.2" clip-path="url(#terminal-3736820236-line-16)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-3736820236-r13" x="585.6" y="410.4" textLength="48.8" clip-path="url(#terminal-3736820236-line-16)">smol</text><text class="terminal-3736820236-r13" x="634.4" y="410.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-16)">-k</text><text class="terminal-3736820236-r13" x="658.8" y="410.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-16)">8s</text><text class="terminal-3736820236-r13" x="683.2" y="410.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-16)">-l</text><text class="terminal-3736820236-r13" x="707.6" y="410.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-16)">ab</text><text class="terminal-3736820236-r9" x="732" y="410.4" textLength="231.8" clip-path="url(#terminal-3736820236-line-16)">&#160;(v5.17.4)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3736820236-r6" x="988.2" y="410.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-16)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="410.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-16)">
-</text><text class="terminal-3736820236-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-17)">│</text><text class="terminal-3736820236-r6" x="988.2" y="434.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-17)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="434.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-17)">
-</text><text class="terminal-3736820236-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-18)">│</text><text class="terminal-3736820236-r7" x="24.4" y="459.2" textLength="24.4" clip-path="url(#terminal-3736820236-line-18)">-f</text><text class="terminal-3736820236-r5" x="61" y="459.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-18)">-</text><text class="terminal-3736820236-r5" x="73.2" y="459.2" textLength="24.4" clip-path="url(#terminal-3736820236-line-18)">-f</text><text class="terminal-3736820236-r5" x="97.6" y="459.2" textLength="97.6" clip-path="url(#terminal-3736820236-line-18)">inal_cmd</text><text class="terminal-3736820236-r1" x="329.4" y="459.2" textLength="366" clip-path="url(#terminal-3736820236-line-18)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-3736820236-r2" x="695.4" y="459.2" textLength="48.8" clip-path="url(#terminal-3736820236-line-18)">smol</text><text class="terminal-3736820236-r2" x="744.2" y="459.2" textLength="24.4" clip-path="url(#terminal-3736820236-line-18)">-k</text><text class="terminal-3736820236-r2" x="768.6" y="459.2" textLength="24.4" clip-path="url(#terminal-3736820236-line-18)">8s</text><text class="terminal-3736820236-r2" x="793" y="459.2" textLength="24.4" clip-path="url(#terminal-3736820236-line-18)">-l</text><text class="terminal-3736820236-r2" x="817.4" y="459.2" textLength="24.4" clip-path="url(#terminal-3736820236-line-18)">ab</text><text class="terminal-3736820236-r1" x="841.8" y="459.2" textLength="122" clip-path="url(#terminal-3736820236-line-18)">&#160;before&#160;&#160;&#160;</text><text class="terminal-3736820236-r6" x="988.2" y="459.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-18)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="459.2" textLength="12.2" clip-path="url(#terminal-3736820236-line-18)">
-</text><text class="terminal-3736820236-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-19)">│</text><text class="terminal-3736820236-r1" x="329.4" y="483.6" textLength="634.4" clip-path="url(#terminal-3736820236-line-19)">main&#160;cli&#160;phase&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3736820236-r6" x="988.2" y="483.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-19)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="483.6" textLength="12.2" clip-path="url(#terminal-3736820236-line-19)">
-</text><text class="terminal-3736820236-r6" x="0" y="508" textLength="12.2" clip-path="url(#terminal-3736820236-line-20)">│</text><text class="terminal-3736820236-r6" x="988.2" y="508" textLength="12.2" clip-path="url(#terminal-3736820236-line-20)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="508" textLength="12.2" clip-path="url(#terminal-3736820236-line-20)">
-</text><text class="terminal-3736820236-r6" x="0" y="532.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-21)">│</text><text class="terminal-3736820236-r10" x="24.4" y="532.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-21)">-h</text><text class="terminal-3736820236-r11" x="61" y="532.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-21)">-</text><text class="terminal-3736820236-r11" x="73.2" y="532.4" textLength="24.4" clip-path="url(#terminal-3736820236-line-21)">-h</text><text class="terminal-3736820236-r11" x="97.6" y="532.4" textLength="36.6" clip-path="url(#terminal-3736820236-line-21)">elp</text><text class="terminal-3736820236-r9" x="329.4" y="532.4" textLength="634.4" clip-path="url(#terminal-3736820236-line-21)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3736820236-r6" x="988.2" y="532.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-21)">│</text><text class="terminal-3736820236-r1" x="1000.4" y="532.4" textLength="12.2" clip-path="url(#terminal-3736820236-line-21)">
-</text><text class="terminal-3736820236-r6" x="0" y="556.8" textLength="24.4" clip-path="url(#terminal-3736820236-line-22)">╰─</text><text class="terminal-3736820236-r6" x="24.4" y="556.8" textLength="329.4" clip-path="url(#terminal-3736820236-line-22)">───────────────────────────</text><text class="terminal-3736820236-r6" x="353.8" y="556.8" textLength="109.8" clip-path="url(#terminal-3736820236-line-22)">&#160;♥&#160;docs:&#160;</text><text class="terminal-3736820236-r6" x="463.6" y="556.8" textLength="500.2" clip-path="url(#terminal-3736820236-line-22)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-3736820236-r6" x="976" y="556.8" textLength="24.4" clip-path="url(#terminal-3736820236-line-22)">─╯</text><text class="terminal-3736820236-r1" x="1000.4" y="556.8" textLength="12.2" clip-path="url(#terminal-3736820236-line-22)">
+    <g class="terminal-1097805467-matrix">
+    <text class="terminal-1097805467-r1" x="158.6" y="20" textLength="329.4" clip-path="url(#terminal-1097805467-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;🧸</text><text class="terminal-1097805467-r2" x="500.2" y="20" textLength="146.4" clip-path="url(#terminal-1097805467-line-0)">smol&#160;k8s&#160;lab</text><text class="terminal-1097805467-r1" x="1122.4" y="20" textLength="12.2" clip-path="url(#terminal-1097805467-line-0)">
+</text><text class="terminal-1097805467-r1" x="1122.4" y="44.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-1)">
+</text><text class="terminal-1097805467-r3" x="158.6" y="68.8" textLength="793" clip-path="url(#terminal-1097805467-line-2)">Install&#160;slim&#160;Kubernetes&#160;distros&#160;+&#160;plus&#160;all&#160;your&#160;apps&#160;via&#160;Argo&#160;CD.</text><text class="terminal-1097805467-r1" x="1122.4" y="68.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-2)">
+</text><text class="terminal-1097805467-r1" x="1122.4" y="93.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-3)">
+</text><text class="terminal-1097805467-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-1097805467-line-4)">Usage:</text><text class="terminal-1097805467-r2" x="85.4" y="117.6" textLength="48.8" clip-path="url(#terminal-1097805467-line-4)">smol</text><text class="terminal-1097805467-r2" x="134.2" y="117.6" textLength="24.4" clip-path="url(#terminal-1097805467-line-4)">-k</text><text class="terminal-1097805467-r2" x="158.6" y="117.6" textLength="24.4" clip-path="url(#terminal-1097805467-line-4)">8s</text><text class="terminal-1097805467-r2" x="183" y="117.6" textLength="24.4" clip-path="url(#terminal-1097805467-line-4)">-l</text><text class="terminal-1097805467-r2" x="207.4" y="117.6" textLength="24.4" clip-path="url(#terminal-1097805467-line-4)">ab</text><text class="terminal-1097805467-r5" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1097805467-line-4)">[OPTIONS]</text><text class="terminal-1097805467-r1" x="1122.4" y="117.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-4)">
+</text><text class="terminal-1097805467-r1" x="1122.4" y="142" textLength="12.2" clip-path="url(#terminal-1097805467-line-5)">
+</text><text class="terminal-1097805467-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1097805467-line-6)">╭─</text><text class="terminal-1097805467-r6" x="24.4" y="166.4" textLength="195.2" clip-path="url(#terminal-1097805467-line-6)">&#160;ʕ&#160;ᵔᴥᵔʔ&#160;Options&#160;</text><text class="terminal-1097805467-r6" x="219.6" y="166.4" textLength="878.4" clip-path="url(#terminal-1097805467-line-6)">────────────────────────────────────────────────────────────────────────</text><text class="terminal-1097805467-r6" x="1098" y="166.4" textLength="24.4" clip-path="url(#terminal-1097805467-line-6)">─╮</text><text class="terminal-1097805467-r1" x="1122.4" y="166.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-6)">
+</text><text class="terminal-1097805467-r6" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-7)">│</text><text class="terminal-1097805467-r6" x="1110.2" y="190.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-7)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-7)">
+</text><text class="terminal-1097805467-r6" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-8)">│</text><text class="terminal-1097805467-r7" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-1097805467-line-8)">-c</text><text class="terminal-1097805467-r5" x="61" y="215.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-8)">-</text><text class="terminal-1097805467-r5" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-1097805467-line-8)">-c</text><text class="terminal-1097805467-r5" x="97.6" y="215.2" textLength="61" clip-path="url(#terminal-1097805467-line-8)">onfig</text><text class="terminal-1097805467-r8" x="158.6" y="215.2" textLength="146.4" clip-path="url(#terminal-1097805467-line-8)">&#160;CONFIG_FILE</text><text class="terminal-1097805467-r1" x="329.4" y="215.2" textLength="756.4" clip-path="url(#terminal-1097805467-line-8)">Full&#160;path&#160;and&#160;name&#160;of&#160;the&#160;YAML&#160;config&#160;file&#160;to&#160;parse.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1097805467-r6" x="1110.2" y="215.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-8)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="215.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-8)">
+</text><text class="terminal-1097805467-r6" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-9)">│</text><text class="terminal-1097805467-r1" x="329.4" y="239.6" textLength="146.4" clip-path="url(#terminal-1097805467-line-9)">Defaults&#160;to&#160;</text><text class="terminal-1097805467-r6" x="475.8" y="239.6" textLength="207.4" clip-path="url(#terminal-1097805467-line-9)">$XDG_CONFIG_HOME/</text><text class="terminal-1097805467-r2" x="683.2" y="239.6" textLength="48.8" clip-path="url(#terminal-1097805467-line-9)">smol</text><text class="terminal-1097805467-r2" x="732" y="239.6" textLength="24.4" clip-path="url(#terminal-1097805467-line-9)">-k</text><text class="terminal-1097805467-r2" x="756.4" y="239.6" textLength="24.4" clip-path="url(#terminal-1097805467-line-9)">8s</text><text class="terminal-1097805467-r2" x="780.8" y="239.6" textLength="24.4" clip-path="url(#terminal-1097805467-line-9)">-l</text><text class="terminal-1097805467-r2" x="805.2" y="239.6" textLength="24.4" clip-path="url(#terminal-1097805467-line-9)">ab</text><text class="terminal-1097805467-r6" x="829.6" y="239.6" textLength="146.4" clip-path="url(#terminal-1097805467-line-9)">/config.yaml</text><text class="terminal-1097805467-r6" x="1110.2" y="239.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-9)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="239.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-9)">
+</text><text class="terminal-1097805467-r6" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1097805467-line-10)">│</text><text class="terminal-1097805467-r6" x="1110.2" y="264" textLength="12.2" clip-path="url(#terminal-1097805467-line-10)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="264" textLength="12.2" clip-path="url(#terminal-1097805467-line-10)">
+</text><text class="terminal-1097805467-r6" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-11)">│</text><text class="terminal-1097805467-r10" x="24.4" y="288.4" textLength="24.4" clip-path="url(#terminal-1097805467-line-11)">-D</text><text class="terminal-1097805467-r11" x="61" y="288.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-11)">-</text><text class="terminal-1097805467-r11" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-1097805467-line-11)">-d</text><text class="terminal-1097805467-r11" x="97.6" y="288.4" textLength="61" clip-path="url(#terminal-1097805467-line-11)">elete</text><text class="terminal-1097805467-r12" x="158.6" y="288.4" textLength="158.6" clip-path="url(#terminal-1097805467-line-11)">&#160;CLUSTER_NAME</text><text class="terminal-1097805467-r9" x="329.4" y="288.4" textLength="756.4" clip-path="url(#terminal-1097805467-line-11)">Delete&#160;an&#160;existing&#160;cluster&#160;by&#160;name.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1097805467-r6" x="1110.2" y="288.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-11)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="288.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-11)">
+</text><text class="terminal-1097805467-r6" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-12)">│</text><text class="terminal-1097805467-r6" x="1110.2" y="312.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-12)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="312.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-12)">
+</text><text class="terminal-1097805467-r6" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-13)">│</text><text class="terminal-1097805467-r7" x="24.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1097805467-line-13)">-i</text><text class="terminal-1097805467-r5" x="61" y="337.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-13)">-</text><text class="terminal-1097805467-r5" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1097805467-line-13)">-i</text><text class="terminal-1097805467-r5" x="97.6" y="337.2" textLength="122" clip-path="url(#terminal-1097805467-line-13)">nteractive</text><text class="terminal-1097805467-r1" x="329.4" y="337.2" textLength="341.6" clip-path="url(#terminal-1097805467-line-13)">⚙️&#160;Interactively&#160;configures&#160;</text><text class="terminal-1097805467-r2" x="658.8" y="337.2" textLength="48.8" clip-path="url(#terminal-1097805467-line-13)">smol</text><text class="terminal-1097805467-r2" x="707.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1097805467-line-13)">-k</text><text class="terminal-1097805467-r2" x="732" y="337.2" textLength="24.4" clip-path="url(#terminal-1097805467-line-13)">8s</text><text class="terminal-1097805467-r2" x="756.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1097805467-line-13)">-l</text><text class="terminal-1097805467-r2" x="780.8" y="337.2" textLength="24.4" clip-path="url(#terminal-1097805467-line-13)">ab</text><text class="terminal-1097805467-r6" x="1110.2" y="337.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-13)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="337.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-13)">
+</text><text class="terminal-1097805467-r6" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-14)">│</text><text class="terminal-1097805467-r6" x="1110.2" y="361.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-14)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="361.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-14)">
+</text><text class="terminal-1097805467-r6" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1097805467-line-15)">│</text><text class="terminal-1097805467-r10" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1097805467-line-15)">-v</text><text class="terminal-1097805467-r11" x="61" y="386" textLength="12.2" clip-path="url(#terminal-1097805467-line-15)">-</text><text class="terminal-1097805467-r11" x="73.2" y="386" textLength="24.4" clip-path="url(#terminal-1097805467-line-15)">-v</text><text class="terminal-1097805467-r11" x="97.6" y="386" textLength="73.2" clip-path="url(#terminal-1097805467-line-15)">ersion</text><text class="terminal-1097805467-r9" x="329.4" y="386" textLength="256.2" clip-path="url(#terminal-1097805467-line-15)">Print&#160;the&#160;version&#160;of&#160;</text><text class="terminal-1097805467-r13" x="585.6" y="386" textLength="48.8" clip-path="url(#terminal-1097805467-line-15)">smol</text><text class="terminal-1097805467-r13" x="634.4" y="386" textLength="24.4" clip-path="url(#terminal-1097805467-line-15)">-k</text><text class="terminal-1097805467-r13" x="658.8" y="386" textLength="24.4" clip-path="url(#terminal-1097805467-line-15)">8s</text><text class="terminal-1097805467-r13" x="683.2" y="386" textLength="24.4" clip-path="url(#terminal-1097805467-line-15)">-l</text><text class="terminal-1097805467-r13" x="707.6" y="386" textLength="24.4" clip-path="url(#terminal-1097805467-line-15)">ab</text><text class="terminal-1097805467-r9" x="732" y="386" textLength="353.8" clip-path="url(#terminal-1097805467-line-15)">&#160;(v5.18.0)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1097805467-r6" x="1110.2" y="386" textLength="12.2" clip-path="url(#terminal-1097805467-line-15)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="386" textLength="12.2" clip-path="url(#terminal-1097805467-line-15)">
+</text><text class="terminal-1097805467-r6" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-16)">│</text><text class="terminal-1097805467-r6" x="1110.2" y="410.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-16)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="410.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-16)">
+</text><text class="terminal-1097805467-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-17)">│</text><text class="terminal-1097805467-r7" x="24.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1097805467-line-17)">-f</text><text class="terminal-1097805467-r5" x="61" y="434.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-17)">-</text><text class="terminal-1097805467-r5" x="73.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1097805467-line-17)">-f</text><text class="terminal-1097805467-r5" x="97.6" y="434.8" textLength="97.6" clip-path="url(#terminal-1097805467-line-17)">inal_cmd</text><text class="terminal-1097805467-r1" x="329.4" y="434.8" textLength="366" clip-path="url(#terminal-1097805467-line-17)">Run&#160;command&#160;immediately&#160;after&#160;</text><text class="terminal-1097805467-r2" x="695.4" y="434.8" textLength="48.8" clip-path="url(#terminal-1097805467-line-17)">smol</text><text class="terminal-1097805467-r2" x="744.2" y="434.8" textLength="24.4" clip-path="url(#terminal-1097805467-line-17)">-k</text><text class="terminal-1097805467-r2" x="768.6" y="434.8" textLength="24.4" clip-path="url(#terminal-1097805467-line-17)">8s</text><text class="terminal-1097805467-r2" x="793" y="434.8" textLength="24.4" clip-path="url(#terminal-1097805467-line-17)">-l</text><text class="terminal-1097805467-r2" x="817.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1097805467-line-17)">ab</text><text class="terminal-1097805467-r1" x="841.8" y="434.8" textLength="244" clip-path="url(#terminal-1097805467-line-17)">&#160;before&#160;main&#160;cli&#160;&#160;&#160;&#160;</text><text class="terminal-1097805467-r6" x="1110.2" y="434.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-17)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="434.8" textLength="12.2" clip-path="url(#terminal-1097805467-line-17)">
+</text><text class="terminal-1097805467-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-18)">│</text><text class="terminal-1097805467-r1" x="329.4" y="459.2" textLength="756.4" clip-path="url(#terminal-1097805467-line-18)">phase&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1097805467-r6" x="1110.2" y="459.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-18)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="459.2" textLength="12.2" clip-path="url(#terminal-1097805467-line-18)">
+</text><text class="terminal-1097805467-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-19)">│</text><text class="terminal-1097805467-r6" x="1110.2" y="483.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-19)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="483.6" textLength="12.2" clip-path="url(#terminal-1097805467-line-19)">
+</text><text class="terminal-1097805467-r6" x="0" y="508" textLength="12.2" clip-path="url(#terminal-1097805467-line-20)">│</text><text class="terminal-1097805467-r10" x="24.4" y="508" textLength="24.4" clip-path="url(#terminal-1097805467-line-20)">-h</text><text class="terminal-1097805467-r11" x="61" y="508" textLength="12.2" clip-path="url(#terminal-1097805467-line-20)">-</text><text class="terminal-1097805467-r11" x="73.2" y="508" textLength="24.4" clip-path="url(#terminal-1097805467-line-20)">-h</text><text class="terminal-1097805467-r11" x="97.6" y="508" textLength="36.6" clip-path="url(#terminal-1097805467-line-20)">elp</text><text class="terminal-1097805467-r9" x="329.4" y="508" textLength="756.4" clip-path="url(#terminal-1097805467-line-20)">Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1097805467-r6" x="1110.2" y="508" textLength="12.2" clip-path="url(#terminal-1097805467-line-20)">│</text><text class="terminal-1097805467-r1" x="1122.4" y="508" textLength="12.2" clip-path="url(#terminal-1097805467-line-20)">
+</text><text class="terminal-1097805467-r6" x="0" y="532.4" textLength="24.4" clip-path="url(#terminal-1097805467-line-21)">╰─</text><text class="terminal-1097805467-r6" x="24.4" y="532.4" textLength="451.4" clip-path="url(#terminal-1097805467-line-21)">─────────────────────────────────────</text><text class="terminal-1097805467-r6" x="475.8" y="532.4" textLength="109.8" clip-path="url(#terminal-1097805467-line-21)">&#160;♥&#160;docs:&#160;</text><text class="terminal-1097805467-r6" x="585.6" y="532.4" textLength="500.2" clip-path="url(#terminal-1097805467-line-21)">https://small-hack.github.io/smol-k8s-lab</text><text class="terminal-1097805467-r6" x="1098" y="532.4" textLength="24.4" clip-path="url(#terminal-1097805467-line-21)">─╯</text><text class="terminal-1097805467-r1" x="1122.4" y="532.4" textLength="12.2" clip-path="url(#terminal-1097805467-line-21)">
 </text>
     </g>
     </g>

--- a/docs/k8s_apps/mastodon.md
+++ b/docs/k8s_apps/mastodon.md
@@ -109,7 +109,7 @@ apps:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:
         # smtp port on your mail server
-        smtp_port: 465
+        smtp_port: 25
         # admin user for your mastodon instance
         admin_user: tootadmin
         # hostname that users go to in the browser

--- a/docs/k8s_apps/mastodon.md
+++ b/docs/k8s_apps/mastodon.md
@@ -71,6 +71,8 @@ apps:
         restic_snapshot_ids:
           seaweedfs_volume: latest
           seaweedfs_filer: latest
+          mastodon_valkey_primary: latest
+          mastodon_valkey_replica: latest
       values:
         # admin user
         admin_user: "tootadmin"

--- a/docs/k8s_apps/mastodon.md
+++ b/docs/k8s_apps/mastodon.md
@@ -108,6 +108,9 @@ apps:
     argo:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:
+        # smtp port on your mail server
+        smtp_port: 465
+        # admin user for your mastodon instance
         admin_user: tootadmin
         # hostname that users go to in the browser
         hostname: ""

--- a/docs/k8s_apps/mastodon.md
+++ b/docs/k8s_apps/mastodon.md
@@ -111,7 +111,7 @@ apps:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:
         # smtp port on your mail server
-        smtp_port: 25
+        smtp_port: '25'
         # admin user for your mastodon instance
         admin_user: tootadmin
         # hostname that users go to in the browser

--- a/poetry.lock
+++ b/poetry.lock
@@ -1217,99 +1217,114 @@ woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "frozenlist"
-version = "1.4.1"
+version = "1.5.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "frozenlist-1.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f9aa1878d1083b276b0196f2dfbe00c9b7e752475ed3b682025ff20c1c1f51ac"},
-    {file = "frozenlist-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29acab3f66f0f24674b7dc4736477bcd4bc3ad4b896f5f45379a67bce8b96868"},
-    {file = "frozenlist-1.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:74fb4bee6880b529a0c6560885fce4dc95936920f9f20f53d99a213f7bf66776"},
-    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:590344787a90ae57d62511dd7c736ed56b428f04cd8c161fcc5e7232c130c69a"},
-    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:068b63f23b17df8569b7fdca5517edef76171cf3897eb68beb01341131fbd2ad"},
-    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5c849d495bf5154cd8da18a9eb15db127d4dba2968d88831aff6f0331ea9bd4c"},
-    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9750cc7fe1ae3b1611bb8cfc3f9ec11d532244235d75901fb6b8e42ce9229dfe"},
-    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9b2de4cf0cdd5bd2dee4c4f63a653c61d2408055ab77b151c1957f221cabf2a"},
-    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0633c8d5337cb5c77acbccc6357ac49a1770b8c487e5b3505c57b949b4b82e98"},
-    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:27657df69e8801be6c3638054e202a135c7f299267f1a55ed3a598934f6c0d75"},
-    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:f9a3ea26252bd92f570600098783d1371354d89d5f6b7dfd87359d669f2109b5"},
-    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:4f57dab5fe3407b6c0c1cc907ac98e8a189f9e418f3b6e54d65a718aaafe3950"},
-    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e02a0e11cf6597299b9f3bbd3f93d79217cb90cfd1411aec33848b13f5c656cc"},
-    {file = "frozenlist-1.4.1-cp310-cp310-win32.whl", hash = "sha256:a828c57f00f729620a442881cc60e57cfcec6842ba38e1b19fd3e47ac0ff8dc1"},
-    {file = "frozenlist-1.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:f56e2333dda1fe0f909e7cc59f021eba0d2307bc6f012a1ccf2beca6ba362439"},
-    {file = "frozenlist-1.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a0cb6f11204443f27a1628b0e460f37fb30f624be6051d490fa7d7e26d4af3d0"},
-    {file = "frozenlist-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b46c8ae3a8f1f41a0d2ef350c0b6e65822d80772fe46b653ab6b6274f61d4a49"},
-    {file = "frozenlist-1.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fde5bd59ab5357e3853313127f4d3565fc7dad314a74d7b5d43c22c6a5ed2ced"},
-    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:722e1124aec435320ae01ee3ac7bec11a5d47f25d0ed6328f2273d287bc3abb0"},
-    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2471c201b70d58a0f0c1f91261542a03d9a5e088ed3dc6c160d614c01649c106"},
-    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c757a9dd70d72b076d6f68efdbb9bc943665ae954dad2801b874c8c69e185068"},
-    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f146e0911cb2f1da549fc58fc7bcd2b836a44b79ef871980d605ec392ff6b0d2"},
-    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f9c515e7914626b2a2e1e311794b4c35720a0be87af52b79ff8e1429fc25f19"},
-    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c302220494f5c1ebeb0912ea782bcd5e2f8308037b3c7553fad0e48ebad6ad82"},
-    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:442acde1e068288a4ba7acfe05f5f343e19fac87bfc96d89eb886b0363e977ec"},
-    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:1b280e6507ea8a4fa0c0a7150b4e526a8d113989e28eaaef946cc77ffd7efc0a"},
-    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:fe1a06da377e3a1062ae5fe0926e12b84eceb8a50b350ddca72dc85015873f74"},
-    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:db9e724bebd621d9beca794f2a4ff1d26eed5965b004a97f1f1685a173b869c2"},
-    {file = "frozenlist-1.4.1-cp311-cp311-win32.whl", hash = "sha256:e774d53b1a477a67838a904131c4b0eef6b3d8a651f8b138b04f748fccfefe17"},
-    {file = "frozenlist-1.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:fb3c2db03683b5767dedb5769b8a40ebb47d6f7f45b1b3e3b4b51ec8ad9d9825"},
-    {file = "frozenlist-1.4.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:1979bc0aeb89b33b588c51c54ab0161791149f2461ea7c7c946d95d5f93b56ae"},
-    {file = "frozenlist-1.4.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:cc7b01b3754ea68a62bd77ce6020afaffb44a590c2289089289363472d13aedb"},
-    {file = "frozenlist-1.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c9c92be9fd329ac801cc420e08452b70e7aeab94ea4233a4804f0915c14eba9b"},
-    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c3894db91f5a489fc8fa6a9991820f368f0b3cbdb9cd8849547ccfab3392d86"},
-    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba60bb19387e13597fb059f32cd4d59445d7b18b69a745b8f8e5db0346f33480"},
-    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8aefbba5f69d42246543407ed2461db31006b0f76c4e32dfd6f42215a2c41d09"},
-    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:780d3a35680ced9ce682fbcf4cb9c2bad3136eeff760ab33707b71db84664e3a"},
-    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9acbb16f06fe7f52f441bb6f413ebae6c37baa6ef9edd49cdd567216da8600cd"},
-    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:23b701e65c7b36e4bf15546a89279bd4d8675faabc287d06bbcfac7d3c33e1e6"},
-    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3e0153a805a98f5ada7e09826255ba99fb4f7524bb81bf6b47fb702666484ae1"},
-    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:dd9b1baec094d91bf36ec729445f7769d0d0cf6b64d04d86e45baf89e2b9059b"},
-    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:1a4471094e146b6790f61b98616ab8e44f72661879cc63fa1049d13ef711e71e"},
-    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5667ed53d68d91920defdf4035d1cdaa3c3121dc0b113255124bcfada1cfa1b8"},
-    {file = "frozenlist-1.4.1-cp312-cp312-win32.whl", hash = "sha256:beee944ae828747fd7cb216a70f120767fc9f4f00bacae8543c14a6831673f89"},
-    {file = "frozenlist-1.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:64536573d0a2cb6e625cf309984e2d873979709f2cf22839bf2d61790b448ad5"},
-    {file = "frozenlist-1.4.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:20b51fa3f588ff2fe658663db52a41a4f7aa6c04f6201449c6c7c476bd255c0d"},
-    {file = "frozenlist-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:410478a0c562d1a5bcc2f7ea448359fcb050ed48b3c6f6f4f18c313a9bdb1826"},
-    {file = "frozenlist-1.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c6321c9efe29975232da3bd0af0ad216800a47e93d763ce64f291917a381b8eb"},
-    {file = "frozenlist-1.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48f6a4533887e189dae092f1cf981f2e3885175f7a0f33c91fb5b7b682b6bab6"},
-    {file = "frozenlist-1.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6eb73fa5426ea69ee0e012fb59cdc76a15b1283d6e32e4f8dc4482ec67d1194d"},
-    {file = "frozenlist-1.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fbeb989b5cc29e8daf7f976b421c220f1b8c731cbf22b9130d8815418ea45887"},
-    {file = "frozenlist-1.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32453c1de775c889eb4e22f1197fe3bdfe457d16476ea407472b9442e6295f7a"},
-    {file = "frozenlist-1.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:693945278a31f2086d9bf3df0fe8254bbeaef1fe71e1351c3bd730aa7d31c41b"},
-    {file = "frozenlist-1.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1d0ce09d36d53bbbe566fe296965b23b961764c0bcf3ce2fa45f463745c04701"},
-    {file = "frozenlist-1.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:3a670dc61eb0d0eb7080890c13de3066790f9049b47b0de04007090807c776b0"},
-    {file = "frozenlist-1.4.1-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:dca69045298ce5c11fd539682cff879cc1e664c245d1c64da929813e54241d11"},
-    {file = "frozenlist-1.4.1-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:a06339f38e9ed3a64e4c4e43aec7f59084033647f908e4259d279a52d3757d09"},
-    {file = "frozenlist-1.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b7f2f9f912dca3934c1baec2e4585a674ef16fe00218d833856408c48d5beee7"},
-    {file = "frozenlist-1.4.1-cp38-cp38-win32.whl", hash = "sha256:e7004be74cbb7d9f34553a5ce5fb08be14fb33bc86f332fb71cbe5216362a497"},
-    {file = "frozenlist-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:5a7d70357e7cee13f470c7883a063aae5fe209a493c57d86eb7f5a6f910fae09"},
-    {file = "frozenlist-1.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bfa4a17e17ce9abf47a74ae02f32d014c5e9404b6d9ac7f729e01562bbee601e"},
-    {file = "frozenlist-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b7e3ed87d4138356775346e6845cccbe66cd9e207f3cd11d2f0b9fd13681359d"},
-    {file = "frozenlist-1.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c99169d4ff810155ca50b4da3b075cbde79752443117d89429595c2e8e37fed8"},
-    {file = "frozenlist-1.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edb678da49d9f72c9f6c609fbe41a5dfb9a9282f9e6a2253d5a91e0fc382d7c0"},
-    {file = "frozenlist-1.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6db4667b187a6742b33afbbaf05a7bc551ffcf1ced0000a571aedbb4aa42fc7b"},
-    {file = "frozenlist-1.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:55fdc093b5a3cb41d420884cdaf37a1e74c3c37a31f46e66286d9145d2063bd0"},
-    {file = "frozenlist-1.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82e8211d69a4f4bc360ea22cd6555f8e61a1bd211d1d5d39d3d228b48c83a897"},
-    {file = "frozenlist-1.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89aa2c2eeb20957be2d950b85974b30a01a762f3308cd02bb15e1ad632e22dc7"},
-    {file = "frozenlist-1.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9d3e0c25a2350080e9319724dede4f31f43a6c9779be48021a7f4ebde8b2d742"},
-    {file = "frozenlist-1.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7268252af60904bf52c26173cbadc3a071cece75f873705419c8681f24d3edea"},
-    {file = "frozenlist-1.4.1-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:0c250a29735d4f15321007fb02865f0e6b6a41a6b88f1f523ca1596ab5f50bd5"},
-    {file = "frozenlist-1.4.1-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:96ec70beabbd3b10e8bfe52616a13561e58fe84c0101dd031dc78f250d5128b9"},
-    {file = "frozenlist-1.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:23b2d7679b73fe0e5a4560b672a39f98dfc6f60df63823b0a9970525325b95f6"},
-    {file = "frozenlist-1.4.1-cp39-cp39-win32.whl", hash = "sha256:a7496bfe1da7fb1a4e1cc23bb67c58fab69311cc7d32b5a99c2007b4b2a0e932"},
-    {file = "frozenlist-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:e6a20a581f9ce92d389a8c7d7c3dd47c81fd5d6e655c8dddf341e14aa48659d0"},
-    {file = "frozenlist-1.4.1-py3-none-any.whl", hash = "sha256:04ced3e6a46b4cfffe20f9ae482818e34eba9b5fb0ce4056e4cc9b6e212d09b7"},
-    {file = "frozenlist-1.4.1.tar.gz", hash = "sha256:c037a86e8513059a2613aaba4d817bb90b9d9b6b69aace3ce9c877e8c8ed402b"},
+    {file = "frozenlist-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5b6a66c18b5b9dd261ca98dffcb826a525334b2f29e7caa54e182255c5f6a65a"},
+    {file = "frozenlist-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d1b3eb7b05ea246510b43a7e53ed1653e55c2121019a97e60cad7efb881a97bb"},
+    {file = "frozenlist-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:15538c0cbf0e4fa11d1e3a71f823524b0c46299aed6e10ebb4c2089abd8c3bec"},
+    {file = "frozenlist-1.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e79225373c317ff1e35f210dd5f1344ff31066ba8067c307ab60254cd3a78ad5"},
+    {file = "frozenlist-1.5.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9272fa73ca71266702c4c3e2d4a28553ea03418e591e377a03b8e3659d94fa76"},
+    {file = "frozenlist-1.5.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:498524025a5b8ba81695761d78c8dd7382ac0b052f34e66939c42df860b8ff17"},
+    {file = "frozenlist-1.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92b5278ed9d50fe610185ecd23c55d8b307d75ca18e94c0e7de328089ac5dcba"},
+    {file = "frozenlist-1.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f3c8c1dacd037df16e85227bac13cca58c30da836c6f936ba1df0c05d046d8d"},
+    {file = "frozenlist-1.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f2ac49a9bedb996086057b75bf93538240538c6d9b38e57c82d51f75a73409d2"},
+    {file = "frozenlist-1.5.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e66cc454f97053b79c2ab09c17fbe3c825ea6b4de20baf1be28919460dd7877f"},
+    {file = "frozenlist-1.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:5a3ba5f9a0dfed20337d3e966dc359784c9f96503674c2faf015f7fe8e96798c"},
+    {file = "frozenlist-1.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6321899477db90bdeb9299ac3627a6a53c7399c8cd58d25da094007402b039ab"},
+    {file = "frozenlist-1.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:76e4753701248476e6286f2ef492af900ea67d9706a0155335a40ea21bf3b2f5"},
+    {file = "frozenlist-1.5.0-cp310-cp310-win32.whl", hash = "sha256:977701c081c0241d0955c9586ffdd9ce44f7a7795df39b9151cd9a6fd0ce4cfb"},
+    {file = "frozenlist-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:189f03b53e64144f90990d29a27ec4f7997d91ed3d01b51fa39d2dbe77540fd4"},
+    {file = "frozenlist-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fd74520371c3c4175142d02a976aee0b4cb4a7cc912a60586ffd8d5929979b30"},
+    {file = "frozenlist-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f3f7a0fbc219fb4455264cae4d9f01ad41ae6ee8524500f381de64ffaa077d5"},
+    {file = "frozenlist-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f47c9c9028f55a04ac254346e92977bf0f166c483c74b4232bee19a6697e4778"},
+    {file = "frozenlist-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0996c66760924da6e88922756d99b47512a71cfd45215f3570bf1e0b694c206a"},
+    {file = "frozenlist-1.5.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2fe128eb4edeabe11896cb6af88fca5346059f6c8d807e3b910069f39157869"},
+    {file = "frozenlist-1.5.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1a8ea951bbb6cacd492e3948b8da8c502a3f814f5d20935aae74b5df2b19cf3d"},
+    {file = "frozenlist-1.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de537c11e4aa01d37db0d403b57bd6f0546e71a82347a97c6a9f0dcc532b3a45"},
+    {file = "frozenlist-1.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c2623347b933fcb9095841f1cc5d4ff0b278addd743e0e966cb3d460278840d"},
+    {file = "frozenlist-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cee6798eaf8b1416ef6909b06f7dc04b60755206bddc599f52232606e18179d3"},
+    {file = "frozenlist-1.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f5f9da7f5dbc00a604fe74aa02ae7c98bcede8a3b8b9666f9f86fc13993bc71a"},
+    {file = "frozenlist-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:90646abbc7a5d5c7c19461d2e3eeb76eb0b204919e6ece342feb6032c9325ae9"},
+    {file = "frozenlist-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:bdac3c7d9b705d253b2ce370fde941836a5f8b3c5c2b8fd70940a3ea3af7f4f2"},
+    {file = "frozenlist-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03d33c2ddbc1816237a67f66336616416e2bbb6beb306e5f890f2eb22b959cdf"},
+    {file = "frozenlist-1.5.0-cp311-cp311-win32.whl", hash = "sha256:237f6b23ee0f44066219dae14c70ae38a63f0440ce6750f868ee08775073f942"},
+    {file = "frozenlist-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:0cc974cc93d32c42e7b0f6cf242a6bd941c57c61b618e78b6c0a96cb72788c1d"},
+    {file = "frozenlist-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:31115ba75889723431aa9a4e77d5f398f5cf976eea3bdf61749731f62d4a4a21"},
+    {file = "frozenlist-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7437601c4d89d070eac8323f121fcf25f88674627505334654fd027b091db09d"},
+    {file = "frozenlist-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7948140d9f8ece1745be806f2bfdf390127cf1a763b925c4a805c603df5e697e"},
+    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feeb64bc9bcc6b45c6311c9e9b99406660a9c05ca8a5b30d14a78555088b0b3a"},
+    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:683173d371daad49cffb8309779e886e59c2f369430ad28fe715f66d08d4ab1a"},
+    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7d57d8f702221405a9d9b40f9da8ac2e4a1a8b5285aac6100f3393675f0a85ee"},
+    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30c72000fbcc35b129cb09956836c7d7abf78ab5416595e4857d1cae8d6251a6"},
+    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:000a77d6034fbad9b6bb880f7ec073027908f1b40254b5d6f26210d2dab1240e"},
+    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5d7f5a50342475962eb18b740f3beecc685a15b52c91f7d975257e13e029eca9"},
+    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:87f724d055eb4785d9be84e9ebf0f24e392ddfad00b3fe036e43f489fafc9039"},
+    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:6e9080bb2fb195a046e5177f10d9d82b8a204c0736a97a153c2466127de87784"},
+    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9b93d7aaa36c966fa42efcaf716e6b3900438632a626fb09c049f6a2f09fc631"},
+    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:52ef692a4bc60a6dd57f507429636c2af8b6046db8b31b18dac02cbc8f507f7f"},
+    {file = "frozenlist-1.5.0-cp312-cp312-win32.whl", hash = "sha256:29d94c256679247b33a3dc96cce0f93cbc69c23bf75ff715919332fdbb6a32b8"},
+    {file = "frozenlist-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:8969190d709e7c48ea386db202d708eb94bdb29207a1f269bab1196ce0dcca1f"},
+    {file = "frozenlist-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7a1a048f9215c90973402e26c01d1cff8a209e1f1b53f72b95c13db61b00f953"},
+    {file = "frozenlist-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dd47a5181ce5fcb463b5d9e17ecfdb02b678cca31280639255ce9d0e5aa67af0"},
+    {file = "frozenlist-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1431d60b36d15cda188ea222033eec8e0eab488f39a272461f2e6d9e1a8e63c2"},
+    {file = "frozenlist-1.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6482a5851f5d72767fbd0e507e80737f9c8646ae7fd303def99bfe813f76cf7f"},
+    {file = "frozenlist-1.5.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:44c49271a937625619e862baacbd037a7ef86dd1ee215afc298a417ff3270608"},
+    {file = "frozenlist-1.5.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:12f78f98c2f1c2429d42e6a485f433722b0061d5c0b0139efa64f396efb5886b"},
+    {file = "frozenlist-1.5.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce3aa154c452d2467487765e3adc730a8c153af77ad84096bc19ce19a2400840"},
+    {file = "frozenlist-1.5.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b7dc0c4338e6b8b091e8faf0db3168a37101943e687f373dce00959583f7439"},
+    {file = "frozenlist-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:45e0896250900b5aa25180f9aec243e84e92ac84bd4a74d9ad4138ef3f5c97de"},
+    {file = "frozenlist-1.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:561eb1c9579d495fddb6da8959fd2a1fca2c6d060d4113f5844b433fc02f2641"},
+    {file = "frozenlist-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:df6e2f325bfee1f49f81aaac97d2aa757c7646534a06f8f577ce184afe2f0a9e"},
+    {file = "frozenlist-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:140228863501b44b809fb39ec56b5d4071f4d0aa6d216c19cbb08b8c5a7eadb9"},
+    {file = "frozenlist-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7707a25d6a77f5d27ea7dc7d1fc608aa0a478193823f88511ef5e6b8a48f9d03"},
+    {file = "frozenlist-1.5.0-cp313-cp313-win32.whl", hash = "sha256:31a9ac2b38ab9b5a8933b693db4939764ad3f299fcaa931a3e605bc3460e693c"},
+    {file = "frozenlist-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:11aabdd62b8b9c4b84081a3c246506d1cddd2dd93ff0ad53ede5defec7886b28"},
+    {file = "frozenlist-1.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:dd94994fc91a6177bfaafd7d9fd951bc8689b0a98168aa26b5f543868548d3ca"},
+    {file = "frozenlist-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2d0da8bbec082bf6bf18345b180958775363588678f64998c2b7609e34719b10"},
+    {file = "frozenlist-1.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:73f2e31ea8dd7df61a359b731716018c2be196e5bb3b74ddba107f694fbd7604"},
+    {file = "frozenlist-1.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:828afae9f17e6de596825cf4228ff28fbdf6065974e5ac1410cecc22f699d2b3"},
+    {file = "frozenlist-1.5.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1577515d35ed5649d52ab4319db757bb881ce3b2b796d7283e6634d99ace307"},
+    {file = "frozenlist-1.5.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2150cc6305a2c2ab33299453e2968611dacb970d2283a14955923062c8d00b10"},
+    {file = "frozenlist-1.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a72b7a6e3cd2725eff67cd64c8f13335ee18fc3c7befc05aed043d24c7b9ccb9"},
+    {file = "frozenlist-1.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c16d2fa63e0800723139137d667e1056bee1a1cf7965153d2d104b62855e9b99"},
+    {file = "frozenlist-1.5.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:17dcc32fc7bda7ce5875435003220a457bcfa34ab7924a49a1c19f55b6ee185c"},
+    {file = "frozenlist-1.5.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:97160e245ea33d8609cd2b8fd997c850b56db147a304a262abc2b3be021a9171"},
+    {file = "frozenlist-1.5.0-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:f1e6540b7fa044eee0bb5111ada694cf3dc15f2b0347ca125ee9ca984d5e9e6e"},
+    {file = "frozenlist-1.5.0-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:91d6c171862df0a6c61479d9724f22efb6109111017c87567cfeb7b5d1449fdf"},
+    {file = "frozenlist-1.5.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:c1fac3e2ace2eb1052e9f7c7db480818371134410e1f5c55d65e8f3ac6d1407e"},
+    {file = "frozenlist-1.5.0-cp38-cp38-win32.whl", hash = "sha256:b97f7b575ab4a8af9b7bc1d2ef7f29d3afee2226bd03ca3875c16451ad5a7723"},
+    {file = "frozenlist-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:374ca2dabdccad8e2a76d40b1d037f5bd16824933bf7bcea3e59c891fd4a0923"},
+    {file = "frozenlist-1.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9bbcdfaf4af7ce002694a4e10a0159d5a8d20056a12b05b45cea944a4953f972"},
+    {file = "frozenlist-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1893f948bf6681733aaccf36c5232c231e3b5166d607c5fa77773611df6dc336"},
+    {file = "frozenlist-1.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2b5e23253bb709ef57a8e95e6ae48daa9ac5f265637529e4ce6b003a37b2621f"},
+    {file = "frozenlist-1.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f253985bb515ecd89629db13cb58d702035ecd8cfbca7d7a7e29a0e6d39af5f"},
+    {file = "frozenlist-1.5.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:04a5c6babd5e8fb7d3c871dc8b321166b80e41b637c31a995ed844a6139942b6"},
+    {file = "frozenlist-1.5.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a9fe0f1c29ba24ba6ff6abf688cb0b7cf1efab6b6aa6adc55441773c252f7411"},
+    {file = "frozenlist-1.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:226d72559fa19babe2ccd920273e767c96a49b9d3d38badd7c91a0fdeda8ea08"},
+    {file = "frozenlist-1.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15b731db116ab3aedec558573c1a5eec78822b32292fe4f2f0345b7f697745c2"},
+    {file = "frozenlist-1.5.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:366d8f93e3edfe5a918c874702f78faac300209a4d5bf38352b2c1bdc07a766d"},
+    {file = "frozenlist-1.5.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1b96af8c582b94d381a1c1f51ffaedeb77c821c690ea5f01da3d70a487dd0a9b"},
+    {file = "frozenlist-1.5.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:c03eff4a41bd4e38415cbed054bbaff4a075b093e2394b6915dca34a40d1e38b"},
+    {file = "frozenlist-1.5.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:50cf5e7ee9b98f22bdecbabf3800ae78ddcc26e4a435515fc72d97903e8488e0"},
+    {file = "frozenlist-1.5.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1e76bfbc72353269c44e0bc2cfe171900fbf7f722ad74c9a7b638052afe6a00c"},
+    {file = "frozenlist-1.5.0-cp39-cp39-win32.whl", hash = "sha256:666534d15ba8f0fda3f53969117383d5dc021266b3c1a42c9ec4855e4b58b9d3"},
+    {file = "frozenlist-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:5c28f4b5dbef8a0d8aad0d4de24d1e9e981728628afaf4ea0792f5d0939372f0"},
+    {file = "frozenlist-1.5.0-py3-none-any.whl", hash = "sha256:d994863bba198a4a518b467bb971c56e1db3f180a25c6cf7bb1949c267f748c3"},
+    {file = "frozenlist-1.5.0.tar.gz", hash = "sha256:81d5af29e61b9c8348e876d442253723928dce6433e0e76cd925cd83f1b4b817"},
 ]
 
 [[package]]
 name = "fsspec"
-version = "2024.9.0"
+version = "2024.10.0"
 description = "File-system specification"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fsspec-2024.9.0-py3-none-any.whl", hash = "sha256:a0947d552d8a6efa72cc2c730b12c41d043509156966cca4fb157b0f2a0c574b"},
-    {file = "fsspec-2024.9.0.tar.gz", hash = "sha256:4b0afb90c2f21832df142f292649035d80b421f60a9e1c027802e5a0da2b04e8"},
+    {file = "fsspec-2024.10.0-py3-none-any.whl", hash = "sha256:03b9a6785766a4de40368b88906366755e2819e758b83705c88cd7cb5fe81871"},
+    {file = "fsspec-2024.10.0.tar.gz", hash = "sha256:eda2d8a4116d4f2429db8550f2457da57279247dd930bb12f821b58391359493"},
 ]
 
 [package.dependencies]
@@ -1546,13 +1561,13 @@ files = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.26.0"
+version = "0.26.1"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "huggingface_hub-0.26.0-py3-none-any.whl", hash = "sha256:e43b8f36042b2103b48dea822535e08f5f089c4aa7013a067fca7b4ebf7f85a3"},
-    {file = "huggingface_hub-0.26.0.tar.gz", hash = "sha256:524fe9281b015b76aa73ff1a83bf1cbe8cab851c9ac5ae5fcd2a25d5173ce629"},
+    {file = "huggingface_hub-0.26.1-py3-none-any.whl", hash = "sha256:5927a8fc64ae68859cd954b7cc29d1c8390a5e15caba6d3d349c973be8fdacf3"},
+    {file = "huggingface_hub-0.26.1.tar.gz", hash = "sha256:414c0d9b769eecc86c70f9d939d0f48bb28e8461dd1130021542eff0212db890"},
 ]
 
 [package.dependencies]
@@ -2779,13 +2794,13 @@ files = [
 
 [[package]]
 name = "networkx"
-version = "3.4.1"
+version = "3.4.2"
 description = "Python package for creating and manipulating graphs and networks"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "networkx-3.4.1-py3-none-any.whl", hash = "sha256:e30a87b48c9a6a7cc220e732bffefaee585bdb166d13377734446ce1a0620eed"},
-    {file = "networkx-3.4.1.tar.gz", hash = "sha256:f9df45e85b78f5bd010993e897b4f1fdb242c11e015b101bd951e5c0e29982d8"},
+    {file = "networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f"},
+    {file = "networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1"},
 ]
 
 [package.extras]
@@ -3425,22 +3440,22 @@ files = [
 
 [[package]]
 name = "protobuf"
-version = "5.28.2"
+version = "5.28.3"
 description = ""
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "protobuf-5.28.2-cp310-abi3-win32.whl", hash = "sha256:eeea10f3dc0ac7e6b4933d32db20662902b4ab81bf28df12218aa389e9c2102d"},
-    {file = "protobuf-5.28.2-cp310-abi3-win_amd64.whl", hash = "sha256:2c69461a7fcc8e24be697624c09a839976d82ae75062b11a0972e41fd2cd9132"},
-    {file = "protobuf-5.28.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a8b9403fc70764b08d2f593ce44f1d2920c5077bf7d311fefec999f8c40f78b7"},
-    {file = "protobuf-5.28.2-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:35cfcb15f213449af7ff6198d6eb5f739c37d7e4f1c09b5d0641babf2cc0c68f"},
-    {file = "protobuf-5.28.2-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:5e8a95246d581eef20471b5d5ba010d55f66740942b95ba9b872d918c459452f"},
-    {file = "protobuf-5.28.2-cp38-cp38-win32.whl", hash = "sha256:87317e9bcda04a32f2ee82089a204d3a2f0d3c8aeed16568c7daf4756e4f1fe0"},
-    {file = "protobuf-5.28.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0ea0123dac3399a2eeb1a1443d82b7afc9ff40241433296769f7da42d142ec3"},
-    {file = "protobuf-5.28.2-cp39-cp39-win32.whl", hash = "sha256:ca53faf29896c526863366a52a8f4d88e69cd04ec9571ed6082fa117fac3ab36"},
-    {file = "protobuf-5.28.2-cp39-cp39-win_amd64.whl", hash = "sha256:8ddc60bf374785fb7cb12510b267f59067fa10087325b8e1855b898a0d81d276"},
-    {file = "protobuf-5.28.2-py3-none-any.whl", hash = "sha256:52235802093bd8a2811abbe8bf0ab9c5f54cca0a751fdd3f6ac2a21438bffece"},
-    {file = "protobuf-5.28.2.tar.gz", hash = "sha256:59379674ff119717404f7454647913787034f03fe7049cbef1d74a97bb4593f0"},
+    {file = "protobuf-5.28.3-cp310-abi3-win32.whl", hash = "sha256:0c4eec6f987338617072592b97943fdbe30d019c56126493111cf24344c1cc24"},
+    {file = "protobuf-5.28.3-cp310-abi3-win_amd64.whl", hash = "sha256:91fba8f445723fcf400fdbe9ca796b19d3b1242cd873907979b9ed71e4afe868"},
+    {file = "protobuf-5.28.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a3f6857551e53ce35e60b403b8a27b0295f7d6eb63d10484f12bc6879c715687"},
+    {file = "protobuf-5.28.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:3fa2de6b8b29d12c61911505d893afe7320ce7ccba4df913e2971461fa36d584"},
+    {file = "protobuf-5.28.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:712319fbdddb46f21abb66cd33cb9e491a5763b2febd8f228251add221981135"},
+    {file = "protobuf-5.28.3-cp38-cp38-win32.whl", hash = "sha256:3e6101d095dfd119513cde7259aa703d16c6bbdfae2554dfe5cfdbe94e32d548"},
+    {file = "protobuf-5.28.3-cp38-cp38-win_amd64.whl", hash = "sha256:27b246b3723692bf1068d5734ddaf2fccc2cdd6e0c9b47fe099244d80200593b"},
+    {file = "protobuf-5.28.3-cp39-cp39-win32.whl", hash = "sha256:135658402f71bbd49500322c0f736145731b16fc79dc8f367ab544a17eab4535"},
+    {file = "protobuf-5.28.3-cp39-cp39-win_amd64.whl", hash = "sha256:70585a70fc2dd4818c51287ceef5bdba6387f88a578c86d47bb34669b5552c36"},
+    {file = "protobuf-5.28.3-py3-none-any.whl", hash = "sha256:cee1757663fa32a1ee673434fcf3bf24dd54763c79690201208bafec62f19eed"},
+    {file = "protobuf-5.28.3.tar.gz", hash = "sha256:64badbc49180a5e401f373f9ce7ab1d18b63f7dd4a9cdc43c92b9f0b481cef7b"},
 ]
 
 [[package]]
@@ -4199,13 +4214,13 @@ rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rich"
-version = "13.9.2"
+version = "13.9.3"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "rich-13.9.2-py3-none-any.whl", hash = "sha256:8c82a3d3f8dcfe9e734771313e606b39d8247bb6b826e196f4914b333b743cf1"},
-    {file = "rich-13.9.2.tar.gz", hash = "sha256:51a2c62057461aaf7152b4d611168f93a9fc73068f8ded2790f29fe2b5366d0c"},
+    {file = "rich-13.9.3-py3-none-any.whl", hash = "sha256:9836f5096eb2172c9e77df411c1b009bace4193d6a481d534fea75ebba758283"},
+    {file = "rich-13.9.3.tar.gz", hash = "sha256:bc1e01b899537598cf02579d2b9f4a415104d3fc439313a7a2c165d76557a08e"},
 ]
 
 [package.dependencies]
@@ -4814,13 +4829,13 @@ catalogue = ">=2.0.3,<2.1.0"
 
 [[package]]
 name = "sudachidict-core"
-version = "20240716"
+version = "20241021"
 description = "Sudachi Dictionary for SudachiPy - Core Edition"
 optional = false
 python-versions = "*"
 files = [
-    {file = "SudachiDict-core-20240716.tar.gz", hash = "sha256:90380263fd3e597240b38001cdcb4d7ae3781fcbf4c92f31cc4d1a4b5c41eea9"},
-    {file = "SudachiDict_core-20240716-py3-none-any.whl", hash = "sha256:29b69eb016c5da7fcbf7cc1dee1c4bdfc323af2e9638106ba62e490f97d86cc9"},
+    {file = "SudachiDict-core-20241021.tar.gz", hash = "sha256:a9d84946f15e040ebf3943ef2b8f0e169c92fb8cf3ce00395bed2698a892069d"},
+    {file = "SudachiDict_core-20241021-py3-none-any.whl", hash = "sha256:c5b61f4b4be5ec76895a51aae051fb8b303a62b3a964f858350edf0d84205378"},
 ]
 
 [package.dependencies]
@@ -4924,13 +4939,13 @@ files = [
 
 [[package]]
 name = "textual"
-version = "0.83.0"
+version = "0.84.0"
 description = "Modern Text User Interface framework"
 optional = false
 python-versions = "<4.0.0,>=3.8.1"
 files = [
-    {file = "textual-0.83.0-py3-none-any.whl", hash = "sha256:d6efc1e5c54086fd0a4fe274f18b5638ca24a69325c07e1b4400a7d0a1a14c55"},
-    {file = "textual-0.83.0.tar.gz", hash = "sha256:fc3b97796092d9c7e685e5392f38f3eb2007ffe1b3b1384dee6d3f10d256babd"},
+    {file = "textual-0.84.0-py3-none-any.whl", hash = "sha256:1457d2cb66ba4ea46812355f31adbb4b693424a94e69d052e4affe1dc410ec96"},
+    {file = "textual-0.84.0.tar.gz", hash = "sha256:fb89717960fea7a539823fa264252f7be1c84844e4b8d27360e6d4edb36846a8"},
 ]
 
 [package.dependencies]
@@ -5678,93 +5693,93 @@ files = [
 
 [[package]]
 name = "yarl"
-version = "1.15.5"
+version = "1.16.0"
 description = "Yet another URL library"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "yarl-1.15.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b6c57972a406ea0f61e3f28f2b3a780fb71fbe1d82d267afe5a2f889a83ee7e7"},
-    {file = "yarl-1.15.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5c3ac5bdcc1375c8ee52784adf94edbce37c471dd2100a117cfef56fe8dbc2b4"},
-    {file = "yarl-1.15.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:68d21d0563d82aaf46163eac529adac301b20be3181b8a2811f7bd5615466055"},
-    {file = "yarl-1.15.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7d317fb80bc17ed4b34a9aad8b80cef34bea0993654f3e8566daf323def7ef9"},
-    {file = "yarl-1.15.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed9c72d5361cfd5af5ccadffa8f8077f4929640e1f938aa0f4b92c5a24996ac5"},
-    {file = "yarl-1.15.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bb707859218e8335447b210f41a755e7b1367c33e87add884128bba144694a7f"},
-    {file = "yarl-1.15.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6563394492c96cb57f4dff0c69c63d2b28b5469c59c66f35a1e6451583cd0ab4"},
-    {file = "yarl-1.15.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c2d1109c8d92059314cc34dd8f0a31f74b720dc140744923ed7ca228bf9b491"},
-    {file = "yarl-1.15.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8fc727f0fb388debc771eaa7091c092bd2e8b6b4741b73354b8efadcf96d6031"},
-    {file = "yarl-1.15.5-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:94189746c5ad62e1014a16298130e696fe593d031d442ef135fb7787b7a1f820"},
-    {file = "yarl-1.15.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b06d8b05d0fafef204d635a4711283ddbf19c7c0facdc61b4b775f6e47e2d4be"},
-    {file = "yarl-1.15.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:de6917946dc6bc237d4b354e38aa13a232e0c7948fdbdb160edee3862e9d735f"},
-    {file = "yarl-1.15.5-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:34816f1d833433a16c4832562a050b0a60eac53dcb71b2032e6ebff82d74b6a7"},
-    {file = "yarl-1.15.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:19e2a4b2935f95fad0949f420514c5d862f5f18058fbbfd8854f496a97d9fd87"},
-    {file = "yarl-1.15.5-cp310-cp310-win32.whl", hash = "sha256:30ca64521f1a96b72886dd9e8652f16eab11891b4572dcfcfc1ad6d6ccb27abd"},
-    {file = "yarl-1.15.5-cp310-cp310-win_amd64.whl", hash = "sha256:86648c53b10c53db8b967a75fb41e0c89dbec7398f6525e34af2b6c456bb0ac0"},
-    {file = "yarl-1.15.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e652aa9f8dfa808bc5b2da4d1f4e286cf1d640570fdfa72ffc0c1d16ba114651"},
-    {file = "yarl-1.15.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:21050b6cd569980fe20ceeab4baeb900d3f7247270475e42bafe117416a5496c"},
-    {file = "yarl-1.15.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:18940191ec9a83bbfe63eea61c3e9d12474bb910d5613bce8fa46e84a80b75b2"},
-    {file = "yarl-1.15.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a082dc948045606f62dca0228ab24f13737180b253378d6443f5b2b9ef8beefe"},
-    {file = "yarl-1.15.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a843e692f9d5402b3455653f4607dc521de2385f01c5cad7ba4a87c46e2ea8d"},
-    {file = "yarl-1.15.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5093a453176a4fad4f9c3006f507cf300546190bb3e27944275a37cfd6323a65"},
-    {file = "yarl-1.15.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2597a589859b94d0a5e2f5d30fee95081867926e57cb751f8b44a7dd92da4e79"},
-    {file = "yarl-1.15.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f5a1ca6eaabfe62718b87eac06d9a47b30cf92ffa065fee9196d3ecd24a3cf1"},
-    {file = "yarl-1.15.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ac83b307cc4b8907345b52994055c6c3c2601ceb6fcb94c5ed6a93c6b4e8257"},
-    {file = "yarl-1.15.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:325e2beb2cd8654b276e7686a3cd203628dd3fe32d5c616e632bc35a2901fb16"},
-    {file = "yarl-1.15.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:75d04ba8ed335042328086e643e01165e0c24598216f72da709b375930ae3bdb"},
-    {file = "yarl-1.15.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7abd7d15aedb3961a967cc65f8144dbbca42e3626a21c5f4f29919cf43eeafb9"},
-    {file = "yarl-1.15.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:294c742a273f44511f14b03a9e06b66094dcdf4bbb75a5e23fead548fd5310ae"},
-    {file = "yarl-1.15.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:63d46606b20f80a6476f1044bab78e1a69c2e0747f174583e2f12fc70bad2170"},
-    {file = "yarl-1.15.5-cp311-cp311-win32.whl", hash = "sha256:b1217102a455e3ac9ac293081093f21f0183e978c7692171ff669fee5296fa28"},
-    {file = "yarl-1.15.5-cp311-cp311-win_amd64.whl", hash = "sha256:5848500b6a01497560969e8c3a7eb1b2570853c74a0ca6f67ebaf6064106c49b"},
-    {file = "yarl-1.15.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d3309ee667f2d9c7ac9ecf44620d6b274bfdd8065b8c5019ff6795dd887b8fed"},
-    {file = "yarl-1.15.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:96ce879799fee124d241ea3b84448378f638e290c49493d00b706f3fd57ec22b"},
-    {file = "yarl-1.15.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c884dfa56b050f718ea3cbbfd972e29a6f07f63a7449b10d9a20d64f7eec92e2"},
-    {file = "yarl-1.15.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0327081978fe186c3390dd4f73f95f825d0bb9c74967e22c2a1a87735974d8f5"},
-    {file = "yarl-1.15.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:524b3bb7dff320e305bc979c65eddc0342548c56ea9241502f907853fe53c408"},
-    {file = "yarl-1.15.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fd56de8b645421ff09c993fdb0ee9c5a3b50d290a8f55793b500d99b34d0c1ce"},
-    {file = "yarl-1.15.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c166ad987265bb343be58cdf4fbc4478cc1d81f2246d2be9a15f94393b269faa"},
-    {file = "yarl-1.15.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d56980374a10c74255fcea6ebcfb0aeca7166d212ee9fd7e823ddef35fb62ad0"},
-    {file = "yarl-1.15.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cbf36099a9b407e1456dbf55844743a98603fcba32d2a46fb3a698d926facf1b"},
-    {file = "yarl-1.15.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d7fa4b033e2f267e37aabcc36949fa89f9f1716a723395912147f9cf3fb437c7"},
-    {file = "yarl-1.15.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:bb129f77ddaea2d8e6e00417b8d907448de3407af4eddacca0a515574ad71493"},
-    {file = "yarl-1.15.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:68e837b3edfcd037f9706157e7cb8efda832de6248c7d9e893e2638356dfae5d"},
-    {file = "yarl-1.15.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5b8af4165e097ff84d9bbb97bb4f4d7f71b9c1c9565a2d0e27d93e5f92dae220"},
-    {file = "yarl-1.15.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:70d074d5a96e0954fe6db81ff356f4361397da1cda3f7c127fc0902f671a087e"},
-    {file = "yarl-1.15.5-cp312-cp312-win32.whl", hash = "sha256:362da97ad4360e4ef1dd24ccdd3bceb18332da7f40026a42f49b7edd686e31c3"},
-    {file = "yarl-1.15.5-cp312-cp312-win_amd64.whl", hash = "sha256:9aa054d97033beac9cb9b19b7c0b8784b85b12cd17879087ca6bffba57884e02"},
-    {file = "yarl-1.15.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5fadcf532fd9f6cbad71485ef8c2462dd9a91d3efc72ca01eb0970792c92552a"},
-    {file = "yarl-1.15.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8b7dd6983c81523f9de0ae6334c3b7a3cb33283936e0525f80c4f713f54a9bb6"},
-    {file = "yarl-1.15.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fcfd663dc88465ebe41c7c938bdc91c4b01cda96a0d64bf38fd66c1877323771"},
-    {file = "yarl-1.15.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd529e637cd23204bd82072f6637cff7af2516ad2c132e8f3342cbc84871f7d1"},
-    {file = "yarl-1.15.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b30f13fac56598474071a4f1ecd66c78fdaf2f8619042d7ca135f72dbb348cf"},
-    {file = "yarl-1.15.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:44088ec0be82fba118ed29b6b429f80bf295297727adae4c257ac297e01e8bcd"},
-    {file = "yarl-1.15.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:607683991bab8607e5158cd290dd8fdaa613442aeab802fe1c237d3a3eee7358"},
-    {file = "yarl-1.15.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da48cdff56b01ea4282a6d04b83b07a2088351a4a3ff7aacc1e7e9b6b04b90b9"},
-    {file = "yarl-1.15.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9162ea117ce8bad8ebc95b7376b4135988acd888d2cf4702f8281e3c11f8b81f"},
-    {file = "yarl-1.15.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:e8aa19c39cb20bfb16f0266df175a6004943122cf20707fbf0cacc21f6468a25"},
-    {file = "yarl-1.15.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5d6be369488d503c8edc14e2f63d71ab2a607041ad216a8ad444fa18e8dea792"},
-    {file = "yarl-1.15.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6e2c674cfe4c03ad7a4d536b1f808221f0d11a360486b4b032d2557c0bd633ad"},
-    {file = "yarl-1.15.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:041bafaa82b77fd4ec2826d42a55461ec86d999adf7ed9644eef7e8a9febb366"},
-    {file = "yarl-1.15.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2eeb9ba53c055740cd282ae9d34eb7970d65e73a46f15adec4b0c1b0f2e55cc2"},
-    {file = "yarl-1.15.5-cp313-cp313-win32.whl", hash = "sha256:73143dd279e641543da52c55652ad7b4c7c5f79e797f124f58f04cc060f14271"},
-    {file = "yarl-1.15.5-cp313-cp313-win_amd64.whl", hash = "sha256:94ab1185900f43760d5487c8e49f5f1a66f864e36092f282f1813597479b9dfa"},
-    {file = "yarl-1.15.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6b3d2767bd64c62909ea33525b954ba05c8f9726bfdf2141d175da4e344f19ae"},
-    {file = "yarl-1.15.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:44359c52af9c383e5107f3b6301446fc8269599721fa42fafb2afb5f31a42dcb"},
-    {file = "yarl-1.15.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6493da9ba5c551978c679ab04856c2cf8f79c316e8ec8c503460a135705edc3b"},
-    {file = "yarl-1.15.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a6b6e95bc621c11cf9ff21012173337e789f2461ebc3b4e5bf65c74ef69adb8"},
-    {file = "yarl-1.15.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7983290ede3aaa2c9620879530849532529b4dcbf5b12a0b6a91163a773eadb9"},
-    {file = "yarl-1.15.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07a4b53abe85813c538b9cdbb02909ebe3734e3af466a587df516e960d500cc8"},
-    {file = "yarl-1.15.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5882faa2a6e684f65ee44f18c701768749a950cbd5e72db452fc07805f6bdec0"},
-    {file = "yarl-1.15.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e27861251d9c094f641d39a8a78dd2371fb9a252ea2f689d1ad353a31d46a0bc"},
-    {file = "yarl-1.15.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8669a110f655c9eb22f16fb68a7d4942020aeaa09f1def584a80183e3e89953c"},
-    {file = "yarl-1.15.5-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:10bfe0bef4cf5ea0383886beda004071faadedf2647048b9f876664284c5b60d"},
-    {file = "yarl-1.15.5-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f7de0d4b6b4d8a77e422eb54d765255c0ec6883ee03b8fd537101633948619d7"},
-    {file = "yarl-1.15.5-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:00bb3a559d7bd006a5302ecd7e409916939106a8cdbe31f4eb5e5b9ffcca57ea"},
-    {file = "yarl-1.15.5-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:06ec070a2d71415f90dbe9d70af3158e7da97a128519dba2d1581156ee27fb92"},
-    {file = "yarl-1.15.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b997a806846c00d1f41d6a251803732837771b2091bead7566f68820e317bfe7"},
-    {file = "yarl-1.15.5-cp39-cp39-win32.whl", hash = "sha256:7825506fbee4055265528ec3532a8197ff26fc53d4978917a4c8ddbb4c1667d7"},
-    {file = "yarl-1.15.5-cp39-cp39-win_amd64.whl", hash = "sha256:71730658be0b5de7c570a9795d7404c577b2313c1db370407092c66f70e04ccb"},
-    {file = "yarl-1.15.5-py3-none-any.whl", hash = "sha256:625f31d6650829fba4030b4e7bdb2d69e41510dddfa29a1da27076c199521757"},
-    {file = "yarl-1.15.5.tar.gz", hash = "sha256:8249147ee81c1cf4d1dc6f26ba28a1b9d92751529f83c308ad02164bb93abd0d"},
+    {file = "yarl-1.16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32468f41242d72b87ab793a86d92f885355bcf35b3355aa650bfa846a5c60058"},
+    {file = "yarl-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:234f3a3032b505b90e65b5bc6652c2329ea7ea8855d8de61e1642b74b4ee65d2"},
+    {file = "yarl-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8a0296040e5cddf074c7f5af4a60f3fc42c0237440df7bcf5183be5f6c802ed5"},
+    {file = "yarl-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de6c14dd7c7c0badba48157474ea1f03ebee991530ba742d381b28d4f314d6f3"},
+    {file = "yarl-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b140e532fe0266003c936d017c1ac301e72ee4a3fd51784574c05f53718a55d8"},
+    {file = "yarl-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:019f5d58093402aa8f6661e60fd82a28746ad6d156f6c5336a70a39bd7b162b9"},
+    {file = "yarl-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c42998fd1cbeb53cd985bff0e4bc25fbe55fd6eb3a545a724c1012d69d5ec84"},
+    {file = "yarl-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c7c30fb38c300fe8140df30a046a01769105e4cf4282567a29b5cdb635b66c4"},
+    {file = "yarl-1.16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e49e0fd86c295e743fd5be69b8b0712f70a686bc79a16e5268386c2defacaade"},
+    {file = "yarl-1.16.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:b9ca7b9147eb1365c8bab03c003baa1300599575effad765e0b07dd3501ea9af"},
+    {file = "yarl-1.16.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:27e11db3f1e6a51081a981509f75617b09810529de508a181319193d320bc5c7"},
+    {file = "yarl-1.16.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8994c42f4ca25df5380ddf59f315c518c81df6a68fed5bb0c159c6cb6b92f120"},
+    {file = "yarl-1.16.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:542fa8e09a581bcdcbb30607c7224beff3fdfb598c798ccd28a8184ffc18b7eb"},
+    {file = "yarl-1.16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2bd6a51010c7284d191b79d3b56e51a87d8e1c03b0902362945f15c3d50ed46b"},
+    {file = "yarl-1.16.0-cp310-cp310-win32.whl", hash = "sha256:178ccb856e265174a79f59721031060f885aca428983e75c06f78aa24b91d929"},
+    {file = "yarl-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe8bba2545427418efc1929c5c42852bdb4143eb8d0a46b09de88d1fe99258e7"},
+    {file = "yarl-1.16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d8643975a0080f361639787415a038bfc32d29208a4bf6b783ab3075a20b1ef3"},
+    {file = "yarl-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:676d96bafc8c2d0039cea0cd3fd44cee7aa88b8185551a2bb93354668e8315c2"},
+    {file = "yarl-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d9525f03269e64310416dbe6c68d3b23e5d34aaa8f47193a1c45ac568cecbc49"},
+    {file = "yarl-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37d5ec034e668b22cf0ce1074d6c21fd2a08b90d11b1b73139b750a8b0dd97"},
+    {file = "yarl-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4f32c4cb7386b41936894685f6e093c8dfaf0960124d91fe0ec29fe439e201d0"},
+    {file = "yarl-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5b8e265a0545637492a7e12fd7038370d66c9375a61d88c5567d0e044ded9202"},
+    {file = "yarl-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:789a3423f28a5fff46fbd04e339863c169ece97c827b44de16e1a7a42bc915d2"},
+    {file = "yarl-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f1d1f45e3e8d37c804dca99ab3cf4ab3ed2e7a62cd82542924b14c0a4f46d243"},
+    {file = "yarl-1.16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:621280719c4c5dad4c1391160a9b88925bb8b0ff6a7d5af3224643024871675f"},
+    {file = "yarl-1.16.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ed097b26f18a1f5ff05f661dc36528c5f6735ba4ce8c9645e83b064665131349"},
+    {file = "yarl-1.16.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2f1fe2b2e3ee418862f5ebc0c0083c97f6f6625781382f828f6d4e9b614eba9b"},
+    {file = "yarl-1.16.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:87dd10bc0618991c66cee0cc65fa74a45f4ecb13bceec3c62d78ad2e42b27a16"},
+    {file = "yarl-1.16.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:4199db024b58a8abb2cfcedac7b1292c3ad421684571aeb622a02f242280e8d6"},
+    {file = "yarl-1.16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:99a9dcd4b71dd5f5f949737ab3f356cfc058c709b4f49833aeffedc2652dac56"},
+    {file = "yarl-1.16.0-cp311-cp311-win32.whl", hash = "sha256:a9394c65ae0ed95679717d391c862dece9afacd8fa311683fc8b4362ce8a410c"},
+    {file = "yarl-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:5b9101f528ae0f8f65ac9d64dda2bb0627de8a50344b2f582779f32fda747c1d"},
+    {file = "yarl-1.16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4ffb7c129707dd76ced0a4a4128ff452cecf0b0e929f2668ea05a371d9e5c104"},
+    {file = "yarl-1.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1a5e9d8ce1185723419c487758d81ac2bde693711947032cce600ca7c9cda7d6"},
+    {file = "yarl-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d743e3118b2640cef7768ea955378c3536482d95550222f908f392167fe62059"},
+    {file = "yarl-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26768342f256e6e3c37533bf9433f5f15f3e59e3c14b2409098291b3efaceacb"},
+    {file = "yarl-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d1b0796168b953bca6600c5f97f5ed407479889a36ad7d17183366260f29a6b9"},
+    {file = "yarl-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:858728086914f3a407aa7979cab743bbda1fe2bdf39ffcd991469a370dd7414d"},
+    {file = "yarl-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5570e6d47bcb03215baf4c9ad7bf7c013e56285d9d35013541f9ac2b372593e7"},
+    {file = "yarl-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66ea8311422a7ba1fc79b4c42c2baa10566469fe5a78500d4e7754d6e6db8724"},
+    {file = "yarl-1.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:649bddcedee692ee8a9b7b6e38582cb4062dc4253de9711568e5620d8707c2a3"},
+    {file = "yarl-1.16.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:3a91654adb7643cb21b46f04244c5a315a440dcad63213033826549fa2435f71"},
+    {file = "yarl-1.16.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b439cae82034ade094526a8f692b9a2b5ee936452de5e4c5f0f6c48df23f8604"},
+    {file = "yarl-1.16.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:571f781ae8ac463ce30bacebfaef2c6581543776d5970b2372fbe31d7bf31a07"},
+    {file = "yarl-1.16.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:aa7943f04f36d6cafc0cf53ea89824ac2c37acbdb4b316a654176ab8ffd0f968"},
+    {file = "yarl-1.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1a5cf32539373ff39d97723e39a9283a7277cbf1224f7aef0c56c9598b6486c3"},
+    {file = "yarl-1.16.0-cp312-cp312-win32.whl", hash = "sha256:a5b6c09b9b4253d6a208b0f4a2f9206e511ec68dce9198e0fbec4f160137aa67"},
+    {file = "yarl-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1208ca14eed2fda324042adf8d6c0adf4a31522fa95e0929027cd487875f0240"},
+    {file = "yarl-1.16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5ace0177520bd4caa99295a9b6fb831d0e9a57d8e0501a22ffaa61b4c024283"},
+    {file = "yarl-1.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7118bdb5e3ed81acaa2095cba7ec02a0fe74b52a16ab9f9ac8e28e53ee299732"},
+    {file = "yarl-1.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:38fec8a2a94c58bd47c9a50a45d321ab2285ad133adefbbadf3012c054b7e656"},
+    {file = "yarl-1.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8791d66d81ee45866a7bb15a517b01a2bcf583a18ebf5d72a84e6064c417e64b"},
+    {file = "yarl-1.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1cf936ba67bc6c734f3aa1c01391da74ab7fc046a9f8bbfa230b8393b90cf472"},
+    {file = "yarl-1.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d1aab176dd55b59f77a63b27cffaca67d29987d91a5b615cbead41331e6b7428"},
+    {file = "yarl-1.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:995d0759004c08abd5d1b81300a91d18c8577c6389300bed1c7c11675105a44d"},
+    {file = "yarl-1.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1bc22e00edeb068f71967ab99081e9406cd56dbed864fc3a8259442999d71552"},
+    {file = "yarl-1.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:35b4f7842154176523e0a63c9b871168c69b98065d05a4f637fce342a6a2693a"},
+    {file = "yarl-1.16.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:7ace71c4b7a0c41f317ae24be62bb61e9d80838d38acb20e70697c625e71f120"},
+    {file = "yarl-1.16.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8f639e3f5795a6568aa4f7d2ac6057c757dcd187593679f035adbf12b892bb00"},
+    {file = "yarl-1.16.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:e8be3aff14f0120ad049121322b107f8a759be76a6a62138322d4c8a337a9e2c"},
+    {file = "yarl-1.16.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:122d8e7986043d0549e9eb23c7fd23be078be4b70c9eb42a20052b3d3149c6f2"},
+    {file = "yarl-1.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0fd9c227990f609c165f56b46107d0bc34553fe0387818c42c02f77974402c36"},
+    {file = "yarl-1.16.0-cp313-cp313-win32.whl", hash = "sha256:595ca5e943baed31d56b33b34736461a371c6ea0038d3baec399949dd628560b"},
+    {file = "yarl-1.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:921b81b8d78f0e60242fb3db615ea3f368827a76af095d5a69f1c3366db3f596"},
+    {file = "yarl-1.16.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:ab2b2ac232110a1fdb0d3ffcd087783edd3d4a6ced432a1bf75caf7b7be70916"},
+    {file = "yarl-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7f8713717a09acbfee7c47bfc5777e685539fefdd34fa72faf504c8be2f3df4e"},
+    {file = "yarl-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cdcffe1dbcb4477d2b4202f63cd972d5baa155ff5a3d9e35801c46a415b7f71a"},
+    {file = "yarl-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a91217208306d82357c67daeef5162a41a28c8352dab7e16daa82e3718852a7"},
+    {file = "yarl-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3ab3ed42c78275477ea8e917491365e9a9b69bb615cb46169020bd0aa5e2d6d3"},
+    {file = "yarl-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:707ae579ccb3262dfaef093e202b4c3fb23c3810e8df544b1111bd2401fd7b09"},
+    {file = "yarl-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad7a852d1cd0b8d8b37fc9d7f8581152add917a98cfe2ea6e241878795f917ae"},
+    {file = "yarl-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3f1cc3d3d4dc574bebc9b387f6875e228ace5748a7c24f49d8f01ac1bc6c31b"},
+    {file = "yarl-1.16.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5ff96da263740779b0893d02b718293cc03400c3a208fc8d8cd79d9b0993e532"},
+    {file = "yarl-1.16.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:3d375a19ba2bfe320b6d873f3fb165313b002cef8b7cc0a368ad8b8a57453837"},
+    {file = "yarl-1.16.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:62c7da0ad93a07da048b500514ca47b759459ec41924143e2ddb5d7e20fd3db5"},
+    {file = "yarl-1.16.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:147b0fcd0ee33b4b5f6edfea80452d80e419e51b9a3f7a96ce98eaee145c1581"},
+    {file = "yarl-1.16.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:504e1fe1cc4f170195320eb033d2b0ccf5c6114ce5bf2f617535c01699479bca"},
+    {file = "yarl-1.16.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:bdcf667a5dec12a48f669e485d70c54189f0639c2157b538a4cffd24a853624f"},
+    {file = "yarl-1.16.0-cp39-cp39-win32.whl", hash = "sha256:e9951afe6557c75a71045148890052cb942689ee4c9ec29f5436240e1fcc73b7"},
+    {file = "yarl-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:7d7aaa8ff95d0840e289423e7dc35696c2b058d635f945bf05b5cd633146b027"},
+    {file = "yarl-1.16.0-py3-none-any.whl", hash = "sha256:e6980a558d8461230c457218bd6c92dfc1d10205548215c2c21d79dc8d0a96f3"},
+    {file = "yarl-1.16.0.tar.gz", hash = "sha256:b6f687ced5510a9a2474bbae96a4352e5ace5fa34dc44a217b0537fec1db00b4"},
 ]
 
 [package.dependencies]
@@ -5775,4 +5790,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "6bc53b66796049592f70ec902ff110c1970c7b798c81811f616f6d25127c25a1"
+content-hash = "6860fd12483f8c7716a2d2ea92569d2c678f081feb847be4afa4e9e6aa8fdf27"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "5.17.4"
+version       = "5.18.0"
 description   = "CLI and TUI to quickly install slimmer Kubernetes distros and then manage apps declaratively using Argo CD"
 authors       = ["Jesse Hitch <jessebot@linux.com>",
                  "Max Roby <emax@cloudydev.net>"]
@@ -40,10 +40,10 @@ pyjwt              = "^2.9"
 python             = ">=3.11,<3.13"
 pyyaml             = "^6.0"
 requests           = "^2.32"
-rich               = "^13.8"
+rich               = "^13.9"
 ruamel-yaml        = "^0.18"
 ruamel-yaml-string = "^0.1"
-textual            = "^0.83.0"
+textual            = "^0.84"
 xdg-base-dirs      = "^6.0"
 pygame             = "^2.5"
 python-ulid        = "^3.0"

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -803,6 +803,8 @@ apps:
           # seaweedfs_master: latest
           seaweedfs_volume: latest
           seaweedfs_filer: latest
+          mastodon_valkey_primary: latest
+          mastodon_valkey_replica: latest
       values:
         # admin user
         admin_user: "tootadmin"

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -843,7 +843,7 @@ apps:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:
         # smtp port on your mail server
-        smtp_port: 25
+        smtp_port: '25'
         # admin user for your mastodon instance
         admin_user: tootadmin
         # hostname that users go to in the browser

--- a/smol_k8s_lab/config/default_config.yaml
+++ b/smol_k8s_lab/config/default_config.yaml
@@ -840,6 +840,9 @@ apps:
     argo:
       # secrets keys to make available to Argo CD ApplicationSets
       secret_keys:
+        # smtp port on your mail server
+        smtp_port: 25
+        # admin user for your mastodon instance
         admin_user: tootadmin
         # hostname that users go to in the browser
         hostname: ""

--- a/smol_k8s_lab/k8s_apps/social/mastodon.py
+++ b/smol_k8s_lab/k8s_apps/social/mastodon.py
@@ -547,22 +547,23 @@ def restore_mastodon(argocd: ArgoCD,
     argocd.k8s.apply_manifests(podconfig_yaml, argocd.namespace)
 
     # then we begin the restic restore of all the mastodon PVCs we lost
-    for pvc in ['valkey-primary', 'valkey-replica']:
+    for pvc in ['valkey_primary', 'valkey_replica']:
         pvc_enabled = secrets.get('valkey_pvc_enabled', 'false')
         if pvc_enabled and pvc_enabled.lower() != 'false':
             # restores the mastodon pvc
-            k8up_restore_pvc(k8s_obj=argocd.k8s,
-                             app='mastodon',
-                             pvc=f'mastodon-{pvc}',
-                             namespace='mastodon',
-                             s3_endpoint=s3_backup_endpoint,
-                             s3_bucket=s3_backup_bucket,
-                             access_key_id=access_key_id,
-                             secret_access_key=secret_access_key,
-                             restic_repo_password=restic_repo_password,
-                             snapshot_id=snapshot_ids[f'mastodon_{pvc}'],
-                             pod_config="file-backups-podconfig"
-                             )
+            k8up_restore_pvc(
+                    k8s_obj=argocd.k8s,
+                    app='mastodon',
+                    pvc=f'mastodon-{pvc.replace("_","-")}',
+                    namespace='mastodon',
+                    s3_endpoint=s3_backup_endpoint,
+                    s3_bucket=s3_backup_bucket,
+                    access_key_id=access_key_id,
+                    secret_access_key=secret_access_key,
+                    restic_repo_password=restic_repo_password,
+                    snapshot_id=snapshot_ids[f'mastodon_{pvc}'],
+                    pod_config="file-backups-podconfig"
+                    )
 
     # todo: from here on out, this could be async to start on other tasks
     # install mastodon as usual, but wait on it this time

--- a/smol_k8s_lab/k8s_apps/social/mastodon.py
+++ b/smol_k8s_lab/k8s_apps/social/mastodon.py
@@ -3,7 +3,9 @@ from smol_k8s_lab.bitwarden.bw_cli import BwCLI, create_custom_field
 from smol_k8s_lab.k8s_apps.operators.minio import create_minio_alias
 from smol_k8s_lab.k8s_apps.social.mastodon_secrets import generate_mastodon_secrets
 from smol_k8s_lab.k8s_tools.argocd_util import ArgoCD
-from smol_k8s_lab.k8s_tools.restores import restore_seaweedfs, restore_cnpg_cluster
+from smol_k8s_lab.k8s_tools.restores import (restore_seaweedfs,
+                                             k8up_restore_pvc,
+                                             restore_cnpg_cluster)
 from smol_k8s_lab.utils.passwords import create_password
 from smol_k8s_lab.utils.rich_cli.console_logging import sub_header, header
 from smol_k8s_lab.utils.run.subproc import subproc
@@ -453,6 +455,7 @@ def setup_bitwarden_items(argocd: ArgoCD,
                 f"Recieved: {e}"
                 )
 
+
 def restore_mastodon(argocd: ArgoCD,
                      mastodon_hostname: str,
                      mastodon_namespace: str,
@@ -460,7 +463,7 @@ def restore_mastodon(argocd: ArgoCD,
                      secrets: dict,
                      restore_dict: dict,
                      backup_dict: dict,
-                     pvc_storage_class: str,
+                     global_pvc_storage_class: str,
                      pgsql_cluster_name: str,
                      bitwarden: BwCLI) -> None:
     """
@@ -475,20 +478,18 @@ def restore_mastodon(argocd: ArgoCD,
     restic_repo_password = backup_dict['restic_repo_pass']
     cnpg_backup_schedule = backup_dict['postgres_schedule']
 
-
-    # apply the external secrets so we can immediately use them for restores
-    # ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
-    # WARNING: change this back to main when done testing
-    # ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
-    revision = argo_dict.get("revision", "add-pvc-helm-chart-for-mastodon")
-    argo_path = argo_dict["path"]
+    # get argo git repo info
+    revision = argo_dict['revision']
+    argo_path = argo_dict['path']
 
     # first we grab existing bitwarden items if they exist
     if bitwarden:
         refresh_bweso(argocd, mastodon_hostname, bitwarden)
+
+        # apply the external secrets so we can immediately use them for restores
         external_secrets_yaml = (
-                "https://raw.githubusercontent.com/small-hack/argocd-apps/"
-                f"{revision}/{argo_path}/external_secrets_argocd_appset.yaml"
+                f"https://raw.githubusercontent.com/small-hack/argocd-apps/{revision}/"
+                f"{argo_path}external_secrets_argocd_appset.yaml"
                 )
         argocd.k8s.apply_manifests(external_secrets_yaml, argocd.namespace)
 
@@ -505,8 +506,10 @@ def restore_mastodon(argocd: ArgoCD,
 
     # then we create all the seaweedfs pvcs we lost and restore them
     snapshot_ids = restore_dict['restic_snapshot_ids']
+    s3_pvc_storage_class = secrets.get("s3_pvc_storage_class", global_pvc_storage_class)
+
     restore_seaweedfs(
-            argocd.k8s,
+            argocd,
             'mastodon',
             mastodon_namespace,
             revision,
@@ -517,35 +520,49 @@ def restore_mastodon(argocd: ArgoCD,
             secret_access_key,
             restic_repo_password,
             s3_pvc_capacity,
-            pvc_storage_class,
+            s3_pvc_storage_class,
             "ReadWriteOnce",
             snapshot_ids['seaweedfs_volume'],
-            snapshot_ids['seaweedfs_filer']
-            )
+            snapshot_ids['seaweedfs_filer'])
 
     # then we finally can restore the postgres database :D
     if restore_dict.get("cnpg_restore", False):
         psql_version = restore_dict.get("postgresql_version", 16)
         s3_endpoint = secrets.get('s3_endpoint', "")
-        restore_cnpg_cluster('mastodon',
+        restore_cnpg_cluster(argocd.k8s,
+                             'mastodon',
                              mastodon_namespace,
                              pgsql_cluster_name,
                              psql_version,
                              s3_endpoint,
                              pg_access_key_id,
                              pg_secret_access_key,
-                             seaweedf_s3_endpoint,
                              pgsql_cluster_name,
                              cnpg_backup_schedule)
 
-    # todo: from here on out, this could be async to start on other tasks
-    # install mastodon as usual
-    argocd.install_app('mastodon', argo_dict)
+    podconfig_yaml = (
+            f"https://raw.githubusercontent.com/small-hack/argocd-apps/{revision}/"
+            f"{argo_path}pvc_argocd_appset.yaml"
+            )
+    argocd.k8s.apply_manifests(podconfig_yaml, argocd.namespace)
 
-    # verify mastodon rolled out
-    rollout = (f"kubectl rollout status -n {mastodon_namespace} "
-               "deployment/mastodon-web-app --watch --timeout 10m")
-    while True:
-        rolled_out = subproc([rollout])
-        if "NotFound" not in rolled_out:
-            break
+    # then we begin the restic restore of all the mastodon PVCs we lost
+    pvc_enabled = secrets.get('valkey_pvc_enabled', 'false')
+    if pvc_enabled and pvc_enabled.lower() != 'false':
+        # restores the mastodon pvc
+        k8up_restore_pvc(argocd.k8s,
+                         'mastodon',
+                         'mastodon-valkey',
+                         'mastodon',
+                         s3_backup_endpoint,
+                         s3_backup_bucket,
+                         access_key_id,
+                         secret_access_key,
+                         restic_repo_password,
+                         snapshot_ids['mastodon_valkey'],
+                         "file-backups-podconfig"
+                         )
+
+    # todo: from here on out, this could be async to start on other tasks
+    # install mastodon as usual, but wait on it this time
+    argocd.install_app('mastodon', argo_dict, True)

--- a/smol_k8s_lab/k8s_apps/social/mastodon.py
+++ b/smol_k8s_lab/k8s_apps/social/mastodon.py
@@ -547,21 +547,22 @@ def restore_mastodon(argocd: ArgoCD,
     argocd.k8s.apply_manifests(podconfig_yaml, argocd.namespace)
 
     # then we begin the restic restore of all the mastodon PVCs we lost
-    pvc_enabled = secrets.get('valkey_pvc_enabled', 'false')
-    if pvc_enabled and pvc_enabled.lower() != 'false':
-        # restores the mastodon pvc
-        k8up_restore_pvc(argocd.k8s,
-                         'mastodon',
-                         'mastodon-valkey',
-                         'mastodon',
-                         s3_backup_endpoint,
-                         s3_backup_bucket,
-                         access_key_id,
-                         secret_access_key,
-                         restic_repo_password,
-                         snapshot_ids['mastodon_valkey'],
-                         "file-backups-podconfig"
-                         )
+    for pvc in ['valkey-primary', 'valkey-replica']:
+        pvc_enabled = secrets.get('valkey_pvc_enabled', 'false')
+        if pvc_enabled and pvc_enabled.lower() != 'false':
+            # restores the mastodon pvc
+            k8up_restore_pvc(k8s_obj=argocd.k8s,
+                             app='mastodon',
+                             pvc=f'mastodon-{pvc}',
+                             namespace='mastodon',
+                             s3_endpoint=s3_backup_endpoint,
+                             s3_bucket=s3_backup_bucket,
+                             access_key_id=access_key_id,
+                             secret_access_key=secret_access_key,
+                             restic_repo_password=restic_repo_password,
+                             snapshot_id=snapshot_ids[f'mastodon_{pvc}'],
+                             pod_config="file-backups-podconfig"
+                             )
 
     # todo: from here on out, this could be async to start on other tasks
     # install mastodon as usual, but wait on it this time

--- a/smol_k8s_lab/k8s_apps/social/nextcloud.py
+++ b/smol_k8s_lab/k8s_apps/social/nextcloud.py
@@ -5,7 +5,6 @@ from smol_k8s_lab.k8s_apps.identity_provider.zitadel_api import Zitadel
 from smol_k8s_lab.k8s_apps.social.nextcloud_occ_commands import Nextcloud
 from smol_k8s_lab.k8s_tools.argocd_util import ArgoCD
 from smol_k8s_lab.k8s_tools.restores import (restore_seaweedfs,
-                                             recreate_pvc,
                                              k8up_restore_pvc,
                                              restore_cnpg_cluster)
 from smol_k8s_lab.utils.passwords import create_password


### PR DESCRIPTION
- add smtp port for mastodon to secret_keys. example:
  ```yaml
  apps:
    mastodon:
      argo:
        # secrets keys to make available to Argo CD ApplicationSets
        secret_keys:
          # smtp port on your mail server
          smtp_port: '25'
  ```
- clean up `restore_mastodon` function to include valkey replica and primary pvc restores, and update config to allow setting their snapshot IDs during restores:
  ```yaml
  apps:
    mastodon:
      init:
        restore:
          restic_snapshot_ids:
            mastodon_valkey_primary: latest
            mastodon_valkey_replica: latest
  ```
- closes #326 
- closes #315